### PR TITLE
Add safeguards for high-privileged callbacks (fixes #603)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to un9n (Deep Tree Echo)
+
+Thank you for your interest in contributing to the Deep Tree Echo cognitive architecture project.
+
+## Getting Started
+
+1. Fork the repository
+2. Create a feature branch from `main`
+3. Make your changes following the guidelines below
+4. Submit a pull request
+
+## Code Style
+
+- Follow Unreal Engine 5.x C++ conventions
+- Use `UCLASS`, `USTRUCT`, `UPROPERTY`, `UFUNCTION` macros appropriately
+- Include `.generated.h` headers for reflection
+- Disable unity builds in new modules for better debugging (`bUseUnity = false`)
+
+## Security Guidelines
+
+### Prohibited Patterns (Require Security Review)
+
+The following patterns are **prohibited without explicit security review** by a project maintainer:
+
+#### High-Privileged Editor Callbacks
+
+Do NOT bind to these delegates in project code without review:
+
+```cpp
+// PROHIBITED - Auto-executes with editor privileges during asset import
+GEditor->GetEditorSubsystem<UImportSubsystem>()->OnAssetPostImport.AddUObject(...);
+GEditor->GetEditorSubsystem<UImportSubsystem>()->OnAssetPreImport.AddUObject(...);
+
+// PROHIBITED - Legacy delegate form
+FEditorDelegates::OnAssetPostImport.AddRaw(...);
+FEditorDelegates::OnAssetPreImport.AddRaw(...);
+```
+
+**Why:** These callbacks execute automatically when assets are imported into the editor. Code bound to them runs with full editor privileges and can perform arbitrary operations without user consent.
+
+#### Build Step Injection
+
+Do NOT add `PreBuildSteps` or `PostBuildSteps` to any `.Target.cs` file:
+
+```csharp
+// PROHIBITED - Executes arbitrary commands during build
+PreBuildSteps.Add("...");
+PostBuildSteps.Add("...");
+```
+
+**Why:** Build steps execute arbitrary shell commands during the UBT build process. They run with the full privileges of the build user and can modify the system without developer awareness.
+
+#### Other High-Risk Patterns
+
+- `FCoreDelegates::OnPreExit` with external network calls
+- `FModuleManager` callbacks that download/execute external code
+- Any callback that writes to system paths outside the project directory
+
+### If You Need These Patterns
+
+If your contribution genuinely requires one of these patterns:
+
+1. Open an issue describing the use case before implementing
+2. Document why no safer alternative exists
+3. Add input validation and scope-limiting guards
+4. Ensure the PR is reviewed by at least two maintainers
+5. Add inline comments explaining the security implications
+
+## Pull Request Process
+
+1. Ensure your code compiles without errors
+2. Add appropriate documentation for new components
+3. Update `CLAUDE.md` if you add new modules or change architecture
+4. Security-sensitive changes require two approvals
+5. Include test coverage for new cognitive components
+
+## Module Structure
+
+When adding a new cognitive component:
+
+1. Create header in the appropriate `DeepTreeEcho/` subdirectory
+2. Inherit from `UActorComponent`
+3. Define state struct with `USTRUCT(BlueprintType)`
+4. Implement in corresponding `.cpp` file
+5. Register with `DeepTreeEchoCore` for tick updates
+
+## Questions?
+
+Open a discussion issue if you have questions about contributing.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,50 @@
-Our Security Approach
+# Security Policy
 
-The Information Security Team at Epic Games is continually working to protect our players, data, products, and services. Our team understands that there is an incredible community of talented security researchers who want to help further strengthen our security.
+## Overview
 
-If you think you've found a vulnerability on one of our sites or within our products, please report it to us by either emailing security@epicgames.com, or directly submitting it to our HackerOne bug bounty program (https://hackerone.com/epicgames). Once submitted our team will work with you to validate, resolve, and award your findings as appropriate.
+This repository (un9n) implements the Deep Tree Echo cognitive architecture for embodied AI avatars using Unreal Engine 5.x. Security is a priority for all project code.
 
-When submitting your vulnerability report, include as much information about your finding as possible - such as domain names, impacted services, and any other relevant information. Please be sure to thoroughly review our program policy prior to submission.
+## High-Privileged Callback Policy
 
-When you submit your vulnerability please be sure to give as much detail as possible. We look forward to hearing from you!
+This project's custom code does **NOT** use any of the following high-privileged editor/build callbacks:
+
+| Callback | Risk | Status |
+|----------|------|--------|
+| `FEditorDelegates::OnAssetPostImport` | Auto-executes with editor privileges during asset import | **Not used** |
+| `FEditorDelegates::OnAssetPreImport` | Auto-executes with editor privileges before asset import | **Not used** |
+| `UBT PreBuildSteps` / `PostBuildSteps` | Executes arbitrary commands during build | **Not used** |
+
+These callbacks exist only in the vendored Unreal Engine source (`Engine/` directory), which is standard Epic Games code and not modified by this project.
+
+### Why These Are Restricted
+
+These callbacks can be automatically invoked by the engine during normal import/build workflows, and logic implemented in them runs with elevated editor privileges. If abused, they could execute malicious code without explicit developer action.
+
+### Policy
+
+Any future use of these callbacks in project code (`DeepTreeEcho/`, `UnrealEcho/`, `ReservoirEcho/`, `Source/`) **requires**:
+1. Explicit security review by a project maintainer
+2. Clear documentation of why the callback is necessary
+3. Input validation and sandboxing where applicable
+4. PR approval from at least two reviewers
+
+## Reporting Security Issues
+
+If you discover a security vulnerability in this project's code, please report it responsibly:
+
+1. **Do not** open a public GitHub issue for security vulnerabilities
+2. Email the maintainers directly or use GitHub's private vulnerability reporting feature
+3. Include detailed reproduction steps and impact assessment
+
+For vulnerabilities in the vendored Unreal Engine source, please report to Epic Games at security@epicgames.com or via their [HackerOne program](https://hackerone.com/epicgames).
+
+## Scope
+
+This security policy covers the project's custom source code:
+- `DeepTreeEcho/` — Core cognitive architecture
+- `UnrealEcho/` — Unreal Engine cognitive components
+- `ReservoirEcho/` — Echo State Network library
+- `MetaHuman-DNA-Calibration/` — MetaHuman rig system
+- `Source/` — UE module build definitions
+
+The `Engine/` directory contains unmodified Unreal Engine 5.3 source governed by Epic Games' security policies.

--- a/Source/ReservoirEcho/ReservoirEcho.Build.cs
+++ b/Source/ReservoirEcho/ReservoirEcho.Build.cs
@@ -2,6 +2,10 @@
 // Unreal Build System module definition for ReservoirEcho bridge
 // Copyright (c) 2026 Deep Tree Echo Project
 
+// SECURITY NOTE: This module intentionally does NOT use PreBuildSteps or
+// PostBuildSteps. Any addition of build steps requires explicit security
+// review per SECURITY.md policy. See issue #603.
+
 using UnrealBuildTool;
 
 public class ReservoirEcho : ModuleRules

--- a/Source/UnrealEcho/UnrealEcho.Build.cs
+++ b/Source/UnrealEcho/UnrealEcho.Build.cs
@@ -9,6 +9,10 @@ public class UnrealEcho : ModuleRules
 	{
 		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
 
+		// SECURITY NOTE: This module intentionally does NOT use PreBuildSteps or
+		// PostBuildSteps. Any addition of build steps requires explicit security
+		// review per SECURITY.md policy. See issue #603.
+
 		// UnrealEcho source directories (relative to repository root)
 		string UnrealEchoRoot = Path.GetFullPath(Path.Combine(ModuleDirectory, "../../UnrealEcho"));
 		string DeepTreeEchoRoot = Path.GetFullPath(Path.Combine(ModuleDirectory, "../../DeepTreeEcho"));


### PR DESCRIPTION
## Summary

Addresses #603 — adds safeguards and documentation for high-privileged RT3DE execution callbacks.

## Investigation

Comprehensive search confirmed that **the project's own code does NOT use** any of the flagged callbacks:
- `FEditorDelegates::OnAssetPostImport` — Not used
- `FEditorDelegates::OnAssetPreImport` — Not used
- `UBT PreBuildSteps` / `PostBuildSteps` — Not used

These patterns exist only in the vendored Unreal Engine source (`Engine/` directory), which is standard Epic Games code.

## Changes

| File | Change |
|------|--------|
| `SECURITY.md` | Replaced generic Epic template with project-specific security policy documenting the high-privileged callback prohibition |
| `CONTRIBUTING.md` | New file with security guidelines for contributors, explicitly prohibiting unsafe callback patterns without review |
| `Source/UnrealEcho/UnrealEcho.Build.cs` | Added security comment noting PreBuildSteps intentionally not used |
| `Source/ReservoirEcho/ReservoirEcho.Build.cs` | Same safeguard comment |

## Policy Established

Any future use of these high-privileged callbacks requires:
1. Explicit security review by a maintainer
2. Documentation of necessity
3. Input validation and sandboxing
4. Two-reviewer PR approval

Fixes: #603

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and comments only; no runtime, auth, or build behavior changes.
> 
> **Overview**
> Documents policy for **high-privileged editor and build callbacks** after confirming project code does not use them (fixes #603).
> 
> **`SECURITY.md`** is rewritten from the generic Epic template to a project-specific policy: documents that `OnAssetPostImport` / `OnAssetPreImport` and UBT `PreBuildSteps` / `PostBuildSteps` are **not used** in custom code, explains risks, defines scope (`DeepTreeEcho/`, `UnrealEcho/`, etc.), and sets requirements for any future use (review, documentation, validation, two approvals). Reporting guidance distinguishes this repo from vendored `Engine/`.
> 
> **`CONTRIBUTING.md`** is new and spells out prohibited patterns (import delegates, build step injection, other high-risk callbacks), the review process if an exception is needed, and standard PR/module contribution notes.
> 
> **`UnrealEcho.Build.cs`** and **`ReservoirEcho.Build.cs`** gain inline comments stating build steps are intentionally omitted and pointing to `SECURITY.md` and issue #603.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70792780aa776c55e76361ec6da58119f8d2c022. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->