### PR TITLE
Fix HighThroughputMessaging test dropping messages due to queue overflow

### DIFF
--- a/DeepTreeEcho/Testing/E2E/NeuralSymbolicPipelineE2E.cpp
+++ b/DeepTreeEcho/Testing/E2E/NeuralSymbolicPipelineE2E.cpp
@@ -1524,6 +1524,13 @@ TEST_F(MessageProtocolE2ETest, BatchReceive)
 
 TEST_F(MessageProtocolE2ETest, HighThroughputMessaging)
 {
+    // Re-initialize with sufficient queue capacity for high-throughput test.
+    // 10K messages across 4 priority levels requires >2500 per queue.
+    MockBidirectionalMessageProtocol::Config config;
+    config.QueueCapacity = 3000;
+    Protocol = std::make_unique<MockBidirectionalMessageProtocol>();
+    Protocol->Initialize(config);
+
     auto start = std::chrono::high_resolution_clock::now();
     
     int numMessages = 10000;


### PR DESCRIPTION
The `HighThroughputMessaging` E2E test was failing because only 4,096 of 10,000 sent messages were received. The test distributes messages across 4 priority levels (`Priority = i % 4`), putting ~2,500 messages per queue -- but the default `QueueCapacity` is only 1,024. Messages exceeding the capacity are silently dropped, and 4 x 1,024 = 4,096 matches the observed count exactly.

The fix re-initializes the protocol with `QueueCapacity = 3000` before the high-throughput test, giving each priority queue enough room for the expected load with margin.

This is a test-configuration issue -- the protocol's drop-on-overflow behavior is correct by design (and tested separately in `QueueCapacityHandling`), but the throughput test needs capacity sized for its workload.

Fixes: #609

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only configuration in an E2E file; no changes to runtime message protocol or queue overflow semantics.
> 
> **Overview**
> Fixes **`HighThroughputMessaging`** failing because the test enqueues **10,000** messages with **`Priority = i % 4`**, so each of the four queues gets ~**2,500** items while the fixture’s default **`QueueCapacity`** is **1,024**. Overflow is **drop-on-full**, which capped deliveries at **4,096** (4 × 1,024).
> 
> The test now **re-initializes** `MockBidirectionalMessageProtocol` with **`QueueCapacity = 3000`** before the send/drain loop so every priority queue can hold the expected load. **Production protocol behavior is unchanged**; overflow is still covered by **`QueueCapacityHandling`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e62be44275f8bc0cffa12e31c4e63cdf9594c8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->