### PR TITLE
Fix 8 Bugbot review findings in bio-cognitive modules

### DIFF
--- a/OpenCogEcho/include/opencog/afi/adapter.hpp
+++ b/OpenCogEcho/include/opencog/afi/adapter.hpp
@@ -14,9 +14,9 @@
  *   compute_sti_adjustments() returns recommended STI changes for ECAN.
  *
  * FEEDBACK SIGNALS (edge-triggered):
- *   City free energy spike (current > prev * 1.5 AND current > 3.0)
+ *   Mean district free energy spike (current > prev * 1.5 AND current > 3.0)
  *     -> CORTISOL +0.05, NE +0.05  (prediction crisis)
- *   City free energy drop (current < prev * 0.7 AND prev > 2.0)
+ *   Mean district free energy drop (current < prev * 0.7 AND prev > 2.0)
  *     -> DA_PHASIC +0.05  (model improvement reward)
  *
  * The AFI adapter does NOT own districts. Districts are registered externally
@@ -67,7 +67,8 @@ public:
      * For each registered active district:
      * 1. Call district->update_metrics() to refresh from generative model
      * 2. Sum free energies for city_free_energy_
-     * 3. Compute variance of free energies for inter_district_divergence_
+     * 3. Compute mean free energy for scale-invariant edge detection
+     * 4. Compute variance of free energies for inter_district_divergence_
      */
     void update_districts() {
         float sum_fe = 0.0f;
@@ -83,7 +84,9 @@ public:
             }
         }
 
+        active_district_count_ = energies.size();
         city_free_energy_ = sum_fe;
+        mean_district_free_energy_ = sum_fe / static_cast<float>(std::max<size_t>(1, active_district_count_));
 
         // Compute variance of district free energies
         if (energies.size() >= 2) {
@@ -152,39 +155,42 @@ public:
     /**
      * @brief Write edge-triggered feedback signals to the bus
      *
-     * Follows the Marduk adapter pattern: compare city free energy to
-     * previous state and emit hormonal signals on significant changes.
+     * Follows the Marduk adapter pattern: compare mean per-district free
+     * energy to previous state and emit hormonal signals on significant changes.
+     * The public city_free_energy() remains the city-wide sum for consumers
+     * that need aggregate load; edge triggers use the mean so registering more
+     * active districts does not create false spikes by count alone.
      *
      * Edge triggers:
-     *   1. City FE spike (current > prev * 1.5 AND current > 3.0)
+     *   1. Mean district FE spike (current > prev * 1.5 AND current > 3.0)
      *      -> CORTISOL +0.05, NE +0.05 (prediction crisis)
-     *   2. City FE drop (current < prev * 0.7 AND prev > 2.0)
+     *   2. Mean district FE drop (current < prev * 0.7 AND prev > 2.0)
      *      -> DA_PHASIC +0.05 (model improvement reward)
      */
     void apply_feedback() {
-        // Skip edge-detection on the very first call: prev_city_free_energy_
-        // starts at 0.0, which would otherwise make the spike condition
+        // Skip edge-detection on the very first call: previous mean district
+        // free energy starts at 0.0, which would otherwise make the spike condition
         // (current > prev * 1.5 && current > 3.0) trivially satisfied by
-        // any city_free_energy_ > 3.0 on tick one — a false "spike" against
+        // any mean_district_free_energy_ > 3.0 on tick one — a false "spike" against
         // a baseline that was never actually observed.
-        if (has_prev_city_free_energy_) {
-            // --- 1. City free energy spike → prediction crisis ---
-            if (city_free_energy_ > prev_city_free_energy_ * 1.5f &&
-                city_free_energy_ > 3.0f) {
+        if (has_prev_mean_district_free_energy_) {
+            // --- 1. Mean district free energy spike → prediction crisis ---
+            if (mean_district_free_energy_ > prev_mean_district_free_energy_ * 1.5f &&
+                mean_district_free_energy_ > 3.0f) {
                 bus_.produce(HormoneId::CORTISOL, 0.05f);
                 bus_.produce(HormoneId::NOREPINEPHRINE, 0.05f);
             }
 
-            // --- 2. City free energy drop → model improvement reward ---
-            if (city_free_energy_ < prev_city_free_energy_ * 0.7f &&
-                prev_city_free_energy_ > 2.0f) {
+            // --- 2. Mean district free energy drop → model improvement reward ---
+            if (mean_district_free_energy_ < prev_mean_district_free_energy_ * 0.7f &&
+                prev_mean_district_free_energy_ > 2.0f) {
                 bus_.produce(HormoneId::DOPAMINE_PHASIC, 0.05f);
             }
         }
 
         // Update previous state for next tick's edge detection
-        prev_city_free_energy_ = city_free_energy_;
-        has_prev_city_free_energy_ = true;
+        prev_mean_district_free_energy_ = mean_district_free_energy_;
+        has_prev_mean_district_free_energy_ = true;
     }
 
     // ========================================================================
@@ -196,14 +202,17 @@ public:
     }
 
     [[nodiscard]] float city_free_energy() const noexcept { return city_free_energy_; }
+    [[nodiscard]] float mean_district_free_energy() const noexcept { return mean_district_free_energy_; }
     [[nodiscard]] float inter_district_divergence() const noexcept { return inter_district_divergence_; }
 
 private:
     std::vector<entelechy::CognitiveDistrict*> districts_;
+    size_t active_district_count_{0};
     float city_free_energy_{0.0f};
+    float mean_district_free_energy_{0.0f};
     float inter_district_divergence_{0.0f};
-    float prev_city_free_energy_{0.0f};
-    bool has_prev_city_free_energy_{false};
+    float prev_mean_district_free_energy_{0.0f};
+    bool has_prev_mean_district_free_energy_{false};
 };
 
 } // namespace opencog::endo

--- a/OpenCogEcho/include/opencog/endocrine/connector.hpp
+++ b/OpenCogEcho/include/opencog/endocrine/connector.hpp
@@ -12,7 +12,9 @@
 #include <opencog/attention/attention_bank.hpp>
 #include <opencog/pln/inference.hpp>
 
+#include <algorithm>
 #include <concepts>
+#include <cmath>
 #include <functional>
 #include <vector>
 
@@ -82,11 +84,15 @@ protected:
 /**
  * @brief Maps hormone concentrations to ECAN configuration parameters
  *
+ * Endocrine modulation owns the absolute hormonal baseline for ECAN. Neural
+ * adapters should compose their transient deltas on top of this current
+ * configuration rather than restoring their own full ECAN baseline.
+ *
  * Mappings:
  *  - Norepinephrine → af_boundary (arousal widens/narrows focus)
  *  - Cortisol → spreading_rate (stress reduces diffuse spreading)
  *  - Dopamine(tonic) → stimulus_wage (reward state increases stimulus value)
- *  - Melatonin → forgetting_threshold (maintenance mode relaxes forgetting)
+ *  - Melatonin → forgetting_threshold (maintenance mode lowers cutoff)
  *  - Serotonin → lti_decay_rate (patience preserves long-term importance)
  */
 class ECANEndocrineAdapter : public EndocrineConnector {
@@ -117,8 +123,9 @@ public:
         // High tonic dopamine → higher stimulus wages (reward amplification)
         cfg.stimulus_wage = base_config_.stimulus_wage * (1.0f + da_tonic * 0.5f);
 
-        // High melatonin → relaxed forgetting (maintenance mode preserves more)
-        cfg.forgetting_threshold = base_config_.forgetting_threshold * (1.0f - melatonin * 0.5f);
+        // High melatonin → lower forgetting cutoff (maintenance mode preserves more)
+        cfg.forgetting_threshold = base_config_.forgetting_threshold
+            - std::abs(base_config_.forgetting_threshold) * melatonin * 0.5f;
 
         // High serotonin → slower LTI decay (patience preserves long-term importance)
         cfg.lti_decay_rate = base_config_.lti_decay_rate * std::max(0.1f, 1.0f - serotonin * 0.5f);
@@ -168,7 +175,8 @@ public:
             static_cast<float>(base_config_.max_iterations) * (0.5f + serotonin));
 
         // Cortisol → demand higher confidence (conservative under stress)
-        cfg.min_confidence = base_config_.min_confidence + cortisol * 0.4f;
+        cfg.min_confidence = std::clamp(
+            base_config_.min_confidence + cortisol * 0.4f, 0.0f, 0.95f);
 
         // Thyroid → attention threshold (processing rate governor)
         cfg.attention_threshold = base_config_.attention_threshold * (1.5f - thyroid);

--- a/OpenCogEcho/include/opencog/endocrine/endocrine_system.hpp
+++ b/OpenCogEcho/include/opencog/endocrine/endocrine_system.hpp
@@ -83,6 +83,7 @@ public:
     // === Core Connectors (ECAN + PLN) ===
 
     void connect_attention(AttentionBank& bank) {
+        attention_bank_ = &bank;
         ecan_adapter_ = std::make_unique<ECANEndocrineAdapter>(bus_, bank);
     }
 
@@ -101,6 +102,9 @@ public:
      */
     void connect_npu(NPUInterface& npu) {
         npu_adapter_ = std::make_unique<NPUEndocrineAdapter>(bus_, npu);
+        if (guidance_connector_) {
+            guidance_connector_->set_npu_source(npu_adapter_.get());
+        }
     }
 
     /**
@@ -113,6 +117,9 @@ public:
      */
     void connect_o9c2(O9C2Interface& o9c2) {
         o9c2_adapter_ = std::make_unique<O9C2EndocrineAdapter>(bus_, o9c2);
+        if (guidance_connector_) {
+            guidance_connector_->set_o9c2_source(o9c2_adapter_.get());
+        }
     }
 
     /**
@@ -126,6 +133,9 @@ public:
      */
     void connect_marduk(MardukInterface& marduk) {
         marduk_adapter_ = std::make_unique<MardukEndocrineAdapter>(bus_, marduk);
+        if (guidance_connector_) {
+            guidance_connector_->set_marduk_source(marduk_adapter_.get());
+        }
     }
 
     /**
@@ -139,6 +149,9 @@ public:
      */
     void connect_touchpad(TouchpadInterface& touchpad) {
         touchpad_adapter_ = std::make_unique<TouchpadEndocrineAdapter>(bus_, touchpad);
+        if (guidance_connector_) {
+            guidance_connector_->set_touchpad_source(touchpad_adapter_.get());
+        }
     }
 
     /**
@@ -294,6 +307,11 @@ public:
         }
         if (afi_adapter_) {
             afi_adapter_->apply_endocrine_modulation(bus_);
+            if (attention_bank_) {
+                for (const auto& [atom, sti_adjustment] : afi_adapter_->compute_sti_adjustments()) {
+                    attention_bank_->stimulate(atom, sti_adjustment);
+                }
+            }
         }
 
         // Phase 4: Bidirectional feedback (WRITE target state back to bus)
@@ -795,6 +813,7 @@ private:
     MoralPerceptionEngine moral_;
 
     // Core adapters
+    AttentionBank* attention_bank_{nullptr};
     std::unique_ptr<ECANEndocrineAdapter> ecan_adapter_;
     std::unique_ptr<PLNEndocrineAdapter> pln_adapter_;
 

--- a/OpenCogEcho/include/opencog/endocrine/guidance_connector.hpp
+++ b/OpenCogEcho/include/opencog/endocrine/guidance_connector.hpp
@@ -9,6 +9,7 @@
  * mode suggestions, and parameter overrides.
  *
  * Uses async futures so guidance requests never block the tick pipeline.
+ * Stale in-flight requests are abandoned after a configurable timeout.
  * Supports pluggable backends (stub, HTTP, MMIO) via GuidanceBackend.
  */
 
@@ -20,10 +21,12 @@
 #include <opencog/endocrine/touchpad_adapter.hpp>
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <future>
 #include <memory>
 #include <optional>
+#include <vector>
 
 namespace opencog::endo {
 
@@ -61,6 +64,11 @@ public:
     void set_o9c2_source(O9C2EndocrineAdapter* o9c2) noexcept { o9c2_adapter_ = o9c2; }
     void set_marduk_source(MardukEndocrineAdapter* marduk) noexcept { marduk_adapter_ = marduk; }
     void set_touchpad_source(TouchpadEndocrineAdapter* tp) noexcept { touchpad_adapter_ = tp; }
+
+    [[nodiscard]] bool has_npu_source() const noexcept { return npu_adapter_ != nullptr; }
+    [[nodiscard]] bool has_o9c2_source() const noexcept { return o9c2_adapter_ != nullptr; }
+    [[nodiscard]] bool has_marduk_source() const noexcept { return marduk_adapter_ != nullptr; }
+    [[nodiscard]] bool has_touchpad_source() const noexcept { return touchpad_adapter_ != nullptr; }
 
     // === Moral perception source ===
 
@@ -116,7 +124,7 @@ public:
     // === State queries ===
 
     [[nodiscard]] bool has_pending_request() const noexcept {
-        return pending_response_.valid();
+        return pending_response_.valid() && !pending_request_timed_out();
     }
 
     [[nodiscard]] uint64_t total_requests() const noexcept { return total_requests_; }
@@ -140,6 +148,8 @@ private:
 
     // Async response tracking
     std::future<GuidanceResponse> pending_response_;
+    std::chrono::steady_clock::time_point request_issued_at_{};
+    std::vector<std::future<GuidanceResponse>> abandoned_futures_;
 
     // State tracking
     uint64_t tick_count_{0};
@@ -269,7 +279,9 @@ private:
         req.context_description = build_context(reason, bus);
 
         // Send async
+        abandon_timed_out_request();
         pending_response_ = backend_->request(req);
+        request_issued_at_ = std::chrono::steady_clock::now();
         ticks_since_last_request_ = 0;
         ++total_requests_;
     }
@@ -307,7 +319,13 @@ private:
     // ================================================================
 
     void apply_pending_response() {
+        cleanup_abandoned_responses();
         if (!pending_response_.valid()) return;
+
+        if (pending_request_timed_out()) {
+            abandon_pending_request();
+            return;
+        }
 
         // Check if ready without blocking
         auto status = pending_response_.wait_for(std::chrono::milliseconds(0));
@@ -318,6 +336,39 @@ private:
 
         ++total_responses_;
         apply_response(resp);
+    }
+
+    [[nodiscard]] bool pending_request_timed_out() const noexcept {
+        if (!pending_response_.valid()) return false;
+        return std::chrono::steady_clock::now() - request_issued_at_ >= config_.request_timeout;
+    }
+
+    void abandon_timed_out_request() {
+        if (pending_request_timed_out()) {
+            abandon_pending_request();
+        }
+    }
+
+    void abandon_pending_request() {
+        abandoned_futures_.push_back(std::move(pending_response_));
+        pending_response_ = {};
+        cleanup_abandoned_responses();
+    }
+
+    void cleanup_abandoned_responses() {
+        auto ready = [](std::future<GuidanceResponse>& f) {
+            return f.valid() &&
+                   f.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready;
+        };
+
+        for (auto it = abandoned_futures_.begin(); it != abandoned_futures_.end();) {
+            if (ready(*it)) {
+                (void)it->get();
+                it = abandoned_futures_.erase(it);
+            } else {
+                ++it;
+            }
+        }
     }
 
     void apply_response(const GuidanceResponse& resp) {

--- a/OpenCogEcho/include/opencog/endocrine/guidance_types.hpp
+++ b/OpenCogEcho/include/opencog/endocrine/guidance_types.hpp
@@ -20,6 +20,7 @@
 #include <opencog/endocrine/touchpad_types.hpp>
 
 #include <array>
+#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <future>
@@ -230,6 +231,8 @@ struct GuidanceConfig {
 
     // Touchpad-specific thresholds
     float touchpad_overload_threshold{0.85f};          ///< Touchpad load triggering overload
+
+    std::chrono::milliseconds request_timeout{30000};  ///< Abandon stale in-flight requests after this duration
 };
 
 } // namespace opencog::endo

--- a/OpenCogEcho/include/opencog/endocrine/marduk_adapter.hpp
+++ b/OpenCogEcho/include/opencog/endocrine/marduk_adapter.hpp
@@ -49,8 +49,8 @@ namespace opencog::endo {
  *   COG_COHERENCE   → validation_threshold↑ (HEMISPHERIC: o9c2 coherence → quality bar)
  *
  * WRITE path (apply_feedback):
- *   Task queue depth           → MARDUK_LOAD (ch16)
- *   Organization metric        → ORG_COHERENCE (ch17)
+ *   Task queue depth           → MARDUK_LOAD (ch16, direct level)
+ *   Organization metric        → ORG_COHERENCE (ch17, direct level)
  *   Consolidation success (Δ)  → serotonin
  *   Optimization complete      → DA_phasic
  *   High cognitive load        → IL6
@@ -173,10 +173,10 @@ public:
         ExecutionMetrics ex = marduk_.execution();
 
         // --- Task queue depth → MARDUK_LOAD channel (16) ---
-        bus_.produce(HormoneId::MARDUK_LOAD, tel.task_queue_depth * 0.1f);
+        bus_.set_concentration(HormoneId::MARDUK_LOAD, tel.task_queue_depth);
 
         // --- Organization metric → ORG_COHERENCE channel (17) ---
-        bus_.produce(HormoneId::ORG_COHERENCE, ex.organization * 0.1f);
+        bus_.set_concentration(HormoneId::ORG_COHERENCE, ex.organization);
 
         // --- Consolidation success (Δ > threshold) → serotonin ---
         float delta_consolidation = tel.consolidation_progress - prev_telemetry_.consolidation_progress;

--- a/OpenCogEcho/include/opencog/nervous/thalamic_adapter.hpp
+++ b/OpenCogEcho/include/opencog/nervous/thalamic_adapter.hpp
@@ -12,20 +12,29 @@
 #include <opencog/nervous/connector.hpp>
 #include <opencog/attention/attention_bank.hpp>
 
+#include <cmath>
+
 namespace opencog::nerv {
 
+/**
+ * @brief Composes transient thalamic ECAN deltas over the current config
+ *
+ * Endocrine ECAN modulation owns the absolute hormonal baseline. This adapter
+ * reads the bank's current config each tick, removes only its previous
+ * thalamic contribution when still present, then applies fresh neural deltas.
+ */
 class ThalamicECANAdapter : public NeuralConnector {
 public:
     ThalamicECANAdapter(NerveBus& bus, AttentionBank& bank)
         : NeuralConnector(bus)
         , bank_(bank)
     {
-        base_config_ = bank_.config();
         prev_gate_ = 0.0f;
     }
 
     void read_signals(const NerveBus& bus) override {
-        ECANConfig cfg = base_config_;
+        ECANConfig cfg = bank_.config();
+        remove_previous_contribution(cfg);
 
         float gate = bus.activation(NeuralChannelId::THALAMIC_GATE);
         float arousal = bus.activation(NeuralChannelId::RETICULAR_ACTIVATION);
@@ -33,17 +42,23 @@ public:
 
         // Gate opening → lower AF boundary (more atoms in attentional focus)
         float gate_delta = rising_edge(gate, prev_gate_, 0.03f);
-        cfg.af_boundary = base_config_.af_boundary - gate * 40.0f - gate_delta * 20.0f;
+        prev_af_delta_ = -gate * 40.0f - gate_delta * 20.0f;
+        cfg.af_boundary += prev_af_delta_;
 
         // Arousal → spreading rate (alert = faster spreading)
-        cfg.spreading_rate = base_config_.spreading_rate * (1.0f + arousal * 0.4f);
+        prev_spreading_multiplier_ = 1.0f + arousal * 0.4f;
+        cfg.spreading_rate *= prev_spreading_multiplier_;
 
         // Attention steering signal → stimulus wages
+        prev_stimulus_multiplier_ = 1.0f;
         if (std::abs(attention) > 0.1f) {
-            cfg.stimulus_wage = base_config_.stimulus_wage * (1.0f + std::abs(attention) * 0.3f);
+            prev_stimulus_multiplier_ = 1.0f + std::abs(attention) * 0.3f;
+            cfg.stimulus_wage *= prev_stimulus_multiplier_;
         }
 
         bank_.set_config(cfg);
+        last_written_config_ = cfg;
+        has_written_config_ = true;
         prev_gate_ = gate;
     }
 
@@ -60,10 +75,34 @@ public:
     }
 
 private:
+    static bool approx_equal(float a, float b) noexcept {
+        return std::abs(a - b) <= 0.0001f;
+    }
+
+    void remove_previous_contribution(ECANConfig& cfg) const {
+        if (!has_written_config_) {
+            return;
+        }
+
+        if (approx_equal(cfg.af_boundary, last_written_config_.af_boundary)) {
+            cfg.af_boundary -= prev_af_delta_;
+        }
+        if (approx_equal(cfg.spreading_rate, last_written_config_.spreading_rate)) {
+            cfg.spreading_rate /= prev_spreading_multiplier_;
+        }
+        if (approx_equal(cfg.stimulus_wage, last_written_config_.stimulus_wage)) {
+            cfg.stimulus_wage /= prev_stimulus_multiplier_;
+        }
+    }
+
     AttentionBank& bank_;
-    ECANConfig base_config_;
     float prev_gate_{0.0f};
     float prev_af_utilization_{0.0f};
+    float prev_af_delta_{0.0f};
+    float prev_spreading_multiplier_{1.0f};
+    float prev_stimulus_multiplier_{1.0f};
+    ECANConfig last_written_config_{};
+    bool has_written_config_{false};
 };
 
 } // namespace opencog::nerv

--- a/OpenCogEcho/tests/test_afi.cpp
+++ b/OpenCogEcho/tests/test_afi.cpp
@@ -8,9 +8,11 @@
  */
 
 #include <opencog/afi/types.hpp>
+#include <opencog/afi/adapter.hpp>
 #include <opencog/afi/blanket.hpp>
 #include <opencog/afi/free_energy.hpp>
 #include <opencog/afi/precision.hpp>
+#include <opencog/endocrine/endocrine_system.hpp>
 
 #include <cmath>
 #include <functional>
@@ -32,6 +34,10 @@ extern bool register_test(const std::string& name, std::function<bool()> func);
 
 using namespace opencog::afi;
 using namespace opencog;
+
+static void set_district_free_energy(entelechy::CognitiveDistrict& district, float free_energy) {
+    district.update_observations({0.5f + std::sqrt(free_energy)});
+}
 
 // ============================================================================
 // MarkovBlanket Tests
@@ -370,5 +376,64 @@ TEST(afi_model_weighted_prediction_error) {
     float wpe = model.weighted_prediction_error();
     // Weighted: (2*1 + 0.5*1) / (2 + 0.5) = 2.5 / 2.5 = 1.0
     ASSERT(wpe > 0.0f);
+    return true;
+}
+
+// ============================================================================
+// AFI Endocrine Adapter Tests
+// ============================================================================
+
+TEST(afi_endocrine_feedback_uses_mean_free_energy_not_district_count) {
+    endo::HormoneBus bus;
+    endo::AFIEndocrineAdapter adapter(bus);
+
+    entelechy::CognitiveDistrict academy(entelechy::DistrictId::ACADEMY);
+    set_district_free_energy(academy, 2.1f);
+    adapter.register_district(&academy);
+
+    adapter.apply_endocrine_modulation(bus);
+    adapter.apply_feedback();
+    const float cortisol_before = bus.concentration(endo::HormoneId::CORTISOL);
+
+    entelechy::CognitiveDistrict market(entelechy::DistrictId::MARKETPLACE);
+    entelechy::CognitiveDistrict observatory(entelechy::DistrictId::OBSERVATORY);
+    entelechy::CognitiveDistrict courthouse(entelechy::DistrictId::COURTHOUSE);
+    set_district_free_energy(market, 2.1f);
+    set_district_free_energy(observatory, 2.1f);
+    set_district_free_energy(courthouse, 2.1f);
+    adapter.register_district(&market);
+    adapter.register_district(&observatory);
+    adapter.register_district(&courthouse);
+
+    adapter.apply_endocrine_modulation(bus);
+    ASSERT_NEAR(adapter.city_free_energy(), 8.4f, 0.001f);
+    ASSERT_NEAR(adapter.mean_district_free_energy(), 2.1f, 0.001f);
+    adapter.apply_feedback();
+
+    ASSERT_NEAR(bus.concentration(endo::HormoneId::CORTISOL), cortisol_before, 0.001f);
+    return true;
+}
+
+TEST(afi_endocrine_system_tick_applies_precision_sti_to_attention_bank) {
+    AtomSpace space;
+    AttentionBank bank(space);
+    endo::EndocrineSystem system(space);
+    system.connect_attention(bank);
+    system.connect_afi();
+
+    Handle signal = space.add_node(AtomType::CONCEPT_NODE, "AFI precision signal");
+    entelechy::CognitiveDistrict district(entelechy::DistrictId::MARKETPLACE);
+    district.update_observations({0.5f});
+    auto& model = const_cast<GenerativeModelState&>(district.model());
+    model.predictions = {0.5f};
+    model.observations = {0.5f};
+    model.weights = {PrecisionWeight(signal.id(), 1.0f)};
+
+    system.afi_adapter()->register_district(&district);
+    const float sti_before = space.get_av(signal).sti;
+    system.tick();
+    const float sti_after = space.get_av(signal).sti;
+
+    ASSERT(sti_after > sti_before);
     return true;
 }

--- a/OpenCogEcho/tests/test_endocrine.cpp
+++ b/OpenCogEcho/tests/test_endocrine.cpp
@@ -13,12 +13,14 @@
 #include <opencog/endocrine/glands/hpa_axis.hpp>
 #include <opencog/endocrine/glands/dopaminergic.hpp>
 #include <opencog/endocrine/glands/circadian.hpp>
+#include <opencog/endocrine/guidance_backends/stub_backend.hpp>
 #include <opencog/endocrine/valence.hpp>
 #include <opencog/endocrine/affect.hpp>
 #include <opencog/endocrine/moral.hpp>
 #include <opencog/core/types.hpp>
 
 #include <cmath>
+#include <future>
 #include <thread>
 #include <vector>
 
@@ -42,6 +44,93 @@ extern bool register_test(const std::string& name, std::function<bool()> func);
 
 using namespace opencog;
 using namespace opencog::endo;
+
+namespace {
+
+struct EndocrineGuidanceMockMarduk : public MardukInterface {
+    MardukEndocrineConfig cfg{MARDUK_MODE_PRESETS[0]};
+    MardukTelemetry tel;
+    ExecutionMetrics ex{0.5f, 0.5f, 0.5f, 0.5f, 0.5f};
+
+    MardukOperationalMode active_mode() const noexcept override {
+        return cfg.active_mode;
+    }
+
+    MardukEndocrineConfig current_config() const noexcept override {
+        return cfg;
+    }
+
+    MardukTelemetry telemetry() const noexcept override {
+        return tel;
+    }
+
+    ExecutionMetrics execution() const noexcept override {
+        return ex;
+    }
+
+    void apply_config(const MardukEndocrineConfig& c) override {
+        cfg = c;
+    }
+
+    void transition_mode(MardukOperationalMode target) override {
+        cfg.active_mode = target;
+    }
+};
+
+struct EndocrineGuidanceMockO9C2 : public O9C2Interface {
+    O9C2PersonaConfig cfg{PERSONA_PRESETS[0]};
+    EmergenceMetrics em{0.5f, 0.5f, 0.5f, 0.5f, 0.5f};
+    O9C2Persona persona{O9C2Persona::CONTEMPLATIVE_SCHOLAR};
+
+    O9C2Persona active_persona() const noexcept override {
+        return persona;
+    }
+
+    O9C2PersonaConfig current_config() const noexcept override {
+        return cfg;
+    }
+
+    EmergenceMetrics emergence() const noexcept override {
+        return em;
+    }
+
+    void apply_config(const O9C2PersonaConfig& c) override {
+        cfg = c;
+    }
+
+    void transition_persona(O9C2Persona target) override {
+        persona = target;
+    }
+};
+
+class NeverCompletingGuidanceBackend : public GuidanceBackend {
+public:
+    std::future<GuidanceResponse> request(const GuidanceRequest& req) override {
+        ++request_count_;
+        last_request_ = req;
+        promises_.emplace_back();
+        return promises_.back().get_future();
+    }
+
+    [[nodiscard]] bool is_available() const noexcept override {
+        return true;
+    }
+
+    [[nodiscard]] std::string_view name() const noexcept override {
+        return "NeverCompletingGuidanceBackend";
+    }
+
+    [[nodiscard]] size_t request_count() const noexcept {
+        return request_count_;
+    }
+
+private:
+    size_t request_count_{0};
+    GuidanceRequest last_request_;
+    std::vector<std::promise<GuidanceResponse>> promises_;
+};
+
+} // namespace
 
 // ============================================================================
 // Type Tests
@@ -705,6 +794,48 @@ TEST(EndocrineSystem_mode_transitions) {
     // Mode should have changed from resting (exact mode depends on dynamics)
     // At minimum, cortisol and NE should be elevated
     ASSERT_GT(sys.bus().concentration(HormoneId::CORTISOL), 0.1f);
+    return true;
+}
+
+TEST(EndocrineSystem_guidance_links_late_sources) {
+    AtomSpace space;
+    EndocrineSystem sys(space);
+    EndocrineGuidanceMockMarduk marduk;
+    EndocrineGuidanceMockO9C2 o9c2;
+
+    sys.connect_guidance(std::make_unique<StubGuidanceBackend>());
+    sys.connect_marduk(marduk);
+    sys.connect_o9c2(o9c2);
+
+    ASSERT(sys.guidance() != nullptr);
+    ASSERT(sys.guidance()->has_marduk_source());
+    ASSERT(sys.guidance()->has_o9c2_source());
+    return true;
+}
+
+TEST(GuidanceConnector_timed_out_request_allows_new_request) {
+    HormoneBus bus;
+    auto backend_ptr = new NeverCompletingGuidanceBackend();
+
+    GuidanceConfig cfg;
+    cfg.cooldown_ticks = 0;
+    cfg.periodic_interval = 1;
+    cfg.request_timeout = std::chrono::hours(1);
+
+    GuidanceConnector connector(bus, std::unique_ptr<GuidanceBackend>(backend_ptr), cfg);
+    connector.tick(bus);
+    ASSERT_EQ(backend_ptr->request_count(), 1u);
+    ASSERT(connector.has_pending_request());
+
+    connector.tick(bus);
+    ASSERT_EQ(backend_ptr->request_count(), 1u);
+
+    cfg.request_timeout = std::chrono::milliseconds(0);
+    connector.set_config(cfg);
+    connector.tick(bus);
+
+    ASSERT_EQ(backend_ptr->request_count(), 2u);
+    ASSERT_EQ(connector.total_requests(), 2u);
     return true;
 }
 

--- a/OpenCogEcho/tests/test_marduk.cpp
+++ b/OpenCogEcho/tests/test_marduk.cpp
@@ -391,6 +391,21 @@ TEST(Marduk_WRITE_organization_to_ORG_COHERENCE) {
     return true;
 }
 
+TEST(Marduk_WRITE_telemetry_channels_are_current_levels) {
+    HormoneBus bus;
+    MockMarduk marduk;
+    MardukEndocrineAdapter adapter(bus, marduk);
+
+    marduk.tel.task_queue_depth = 0.6f;
+    marduk.ex.organization = 0.8f;
+    adapter.apply_feedback();
+    adapter.apply_feedback();
+
+    ASSERT_NEAR(bus.concentration(HormoneId::MARDUK_LOAD), 0.6f, 0.01f);
+    ASSERT_NEAR(bus.concentration(HormoneId::ORG_COHERENCE), 0.8f, 0.01f);
+    return true;
+}
+
 TEST(Marduk_WRITE_consolidation_success_to_serotonin) {
     HormoneBus bus;
     MockMarduk marduk;

--- a/OpenCogEcho/tests/test_neuroendocrine.cpp
+++ b/OpenCogEcho/tests/test_neuroendocrine.cpp
@@ -8,9 +8,12 @@
 
 #include <opencog/nervous/neuroendocrine_bridge.hpp>
 #include <opencog/nervous/nerve_bus.hpp>
+#include <opencog/nervous/thalamic_adapter.hpp>
+#include <opencog/endocrine/connector.hpp>
 #include <opencog/endocrine/hormone_bus.hpp>
 #include <opencog/endocrine/types.hpp>
 #include <opencog/nervous/types.hpp>
+#include <opencog/atomspace/atomspace.hpp>
 
 #include <cmath>
 
@@ -317,6 +320,87 @@ TEST(NeuroEndocrine_homeostatic_summary) {
     // Homeostatic signal should reflect the summary
     float homeostatic = nerve_bus.activation(NeuralChannelId::HOMEOSTATIC_SIGNAL);
     ASSERT_GT(std::abs(homeostatic), 0.0f);
+    return true;
+}
+
+// ============================================================================
+// ECAN/PLN Adapter Regression Tests
+// ============================================================================
+
+TEST(NeuroEndocrine_melatonin_lowers_forgetting_cutoff) {
+    AtomSpace space;
+    ECANConfig config;
+    config.forgetting_threshold = -100.0f;
+    AttentionBank bank(space, config);
+    endo::HormoneBus hormone_bus;
+    endo::ECANEndocrineAdapter adapter(hormone_bus, bank);
+
+    hormone_bus.produce(endo::HormoneId::MELATONIN, 1.0f);
+    adapter.apply_endocrine_modulation(hormone_bus);
+
+    ASSERT_LT(bank.config().forgetting_threshold, config.forgetting_threshold);
+    ASSERT_NEAR(bank.config().forgetting_threshold, -150.0f, 0.001f);
+    return true;
+}
+
+TEST(NeuroEndocrine_cortisol_clamps_pln_min_confidence) {
+    AtomSpace space;
+    pln::InferenceConfig config;
+    config.min_confidence = 0.8f;
+    pln::PLNEngine engine(space, config);
+    endo::HormoneBus hormone_bus;
+    endo::PLNEndocrineAdapter adapter(hormone_bus, engine);
+
+    hormone_bus.produce(endo::HormoneId::CORTISOL, 1.0f);
+    adapter.apply_endocrine_modulation(hormone_bus);
+
+    ASSERT_LE(engine.config().min_confidence, 0.95f);
+    ASSERT_NEAR(engine.config().min_confidence, 0.95f, 0.001f);
+    return true;
+}
+
+TEST(NeuroEndocrine_thalamic_adapter_composes_over_endocrine_config) {
+    AtomSpace space;
+    ECANConfig config;
+    config.af_boundary = 0.0f;
+    config.spreading_rate = 0.1f;
+    config.stimulus_wage = 10.0f;
+    config.forgetting_threshold = -100.0f;
+    config.lti_decay_rate = 0.01f;
+    AttentionBank bank(space, config);
+
+    endo::HormoneBus hormone_bus;
+    hormone_bus.produce(endo::HormoneId::NOREPINEPHRINE, 0.5f);
+    hormone_bus.produce(endo::HormoneId::CORTISOL, 0.5f);
+    hormone_bus.produce(endo::HormoneId::DOPAMINE_TONIC, 0.5f);
+    hormone_bus.produce(endo::HormoneId::MELATONIN, 0.8f);
+    hormone_bus.produce(endo::HormoneId::SEROTONIN, 0.4f);
+    endo::ECANEndocrineAdapter endocrine_adapter(hormone_bus, bank);
+    endocrine_adapter.apply_endocrine_modulation(hormone_bus);
+
+    ECANConfig endocrine_config = bank.config();
+    ASSERT_LT(endocrine_config.af_boundary, config.af_boundary);
+    ASSERT_LT(endocrine_config.forgetting_threshold, config.forgetting_threshold);
+
+    NerveBusConfig nerve_config;
+    nerve_config.enable_propagation = false;
+    nerve_config.global_decay_rate = 0.0f;
+    NerveBus nerve_bus(nerve_config);
+    ThalamicECANAdapter thalamic_adapter(nerve_bus, bank);
+    nerve_bus.set_activation(NeuralChannelId::THALAMIC_GATE, 0.5f);
+    nerve_bus.set_activation(NeuralChannelId::RETICULAR_ACTIVATION, 0.5f);
+    nerve_bus.set_activation(NeuralChannelId::MOTOR_ATTENTION, 0.5f);
+
+    thalamic_adapter.read_signals(nerve_bus);
+    ECANConfig composed_config = bank.config();
+
+    ASSERT_LT(composed_config.af_boundary, endocrine_config.af_boundary);
+    ASSERT_GT(composed_config.spreading_rate, endocrine_config.spreading_rate);
+    ASSERT_GT(composed_config.stimulus_wage, endocrine_config.stimulus_wage);
+    ASSERT_NEAR(composed_config.forgetting_threshold,
+                endocrine_config.forgetting_threshold, 0.001f);
+    ASSERT_NEAR(composed_config.lti_decay_rate,
+                endocrine_config.lti_decay_rate, 0.001f);
     return true;
 }
 


### PR DESCRIPTION
- endocrine/connector.hpp: melatonin now lowers the forgetting cutoff (sign-robust vs. negative baseline); PLN min_confidence clamped to [0, 0.95] so stress cannot halt inference.
- nervous/thalamic_adapter.hpp: thalamic ECAN adapter composes transient deltas over the bank's current config instead of rewriting from its own baseline, so endocrine and neural modulation no longer overwrite each other.
- afi/adapter.hpp: edge triggers use mean per-district free energy so district count alone cannot fire cortisol/dopamine spikes; city sum still exposed for aggregate consumers.
- endocrine/endocrine_system.hpp: tick() applies AFI STI adjustments to the connected AttentionBank (precision -> attention bridge now live); late connect_npu/o9c2/marduk/touchpad re-link guidance sources.
- endocrine/marduk_adapter.hpp: MARDUK_LOAD / ORG_COHERENCE written as direct levels via set_concentration instead of accumulating produce().
- endocrine/guidance_connector.hpp + guidance_types.hpp: stale in-flight guidance requests abandoned after configurable request_timeout so a stuck backend cannot block future triggers; non-blocking cleanup of abandoned futures; has_*_source accessors.

Adds 8 regression tests (639 total, all passing).

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Please fill out this form, failure to do so may result in the Pull Request being automatically closed -->
<!--- Describe your change in detail here. -->

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
- [ ] My code adheres to the **[Epic coding standards](https://docs.unrealengine.com/latest/INT/Programming/Development/CodingStandard/)**
- [ ] This change does not include source code created by Generative AI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches tick-pipeline ordering (attention STI, hormone channels, ECAN config composition) and guidance async behavior; changes are targeted with tests but affect core cognitive modulation paths.
> 
> **Overview**
> Fixes several **false-signal and overwrite bugs** in the endocrine, AFI, Marduk, guidance, and thalamic integration paths.
> 
> **AFI** edge-triggered cortisol/NE/DA feedback now compares **mean per-district** free energy (city sum unchanged for aggregate consumers), so adding districts with the same per-district FE no longer looks like a crisis spike. **EndocrineSystem** applies AFI precision **STI adjustments** to the connected **AttentionBank** each tick, and **re-links guidance** when NPU/o9c2/Marduk/Touchpad connect after guidance.
> 
> **ECAN/PLN**: melatonin lowers forgetting cutoff in a sign-safe way; cortisol-driven **min_confidence** is clamped to `[0, 0.95]`. **ThalamicECANAdapter** layers neural deltas on the bank’s **current** config (undoing its prior contribution) so it no longer fights endocrine baseline writes.
> 
> **Marduk** writes **MARDUK_LOAD** and **ORG_COHERENCE** as direct levels via `set_concentration` instead of accumulating with `produce`. **GuidanceConnector** abandons in-flight requests after configurable **request_timeout** so stuck backends cannot block new triggers; adds `has_*_source` for wiring checks.
> 
> Eight regression tests cover these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8675dcbe3085ea8def76f8ace8c1732b411a834f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->