### PR TITLE
Add NanEcho cognitive kernel daemon with Autognosis self-images

### DIFF
--- a/DeepTreeEcho/NanEcho/Kernel/NanEchoKernel.h
+++ b/DeepTreeEcho/NanEcho/Kernel/NanEchoKernel.h
@@ -1,0 +1,636 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// NanEchoKernel — Cognitive kernel daemon for the NanEcho training pipeline
+//
+// Standalone C++17 (no Unreal Engine dependencies). Implements the cognitive
+// kernel that orchestrates echoself's NanEcho model training as described in
+// NANECHO.md, combined with the Autognosis hierarchical self-image system
+// described in AUTOGNOSIS.md:
+//
+//   - Adaptive attention:  threshold = 0.5 + load*0.3 - activity*0.2
+//   - Five blended training phases (Basic Awareness → Adaptive Mastery)
+//   - Weighted fidelity metrics with automated quality gates
+//   - Autognosis self-images at L0 (observation), L1 (pattern analysis),
+//     L2 (meta-cognitive analysis)
+//   - Daemon lifecycle: Configure → Start → Tick → Stop
+//
+// Configuration mirrors Training/NanEchoConfig.h (FNanEchoTrainingConfig);
+// the UE USTRUCT can be converted field-for-field to FNanEchoKernelConfig
+// at the engine boundary.
+// ═══════════════════════════════════════════════════════════════════════════
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace nanecho
+{
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Configuration (plain-C++ mirror of FNanEchoTrainingConfig)
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct FNanEchoKernelConfig
+{
+    // Model architecture
+    std::string BaseModel = "gpt2";
+    int32_t MaxSequenceLength = 1024;
+    int32_t VocabSize = 50257;
+
+    // ESN augmentation
+    bool bESNAugmentation = true;
+    int32_t ESNReservoirSize = 512;
+    float ESNSpectralRadius = 0.9f;
+    float ESNLeakRate = 0.3f;
+
+    // Training hyperparameters
+    float LearningRate = 5e-5f;
+    int32_t BatchSize = 8;
+    int32_t EpochsPerCycle = 3;
+    float WeightDecay = 0.01f;
+    int32_t WarmupSteps = 100;
+
+    // Persona integration
+    bool bEnforcePersona = true;
+    std::string PersonaName = "Deep Tree Echo";
+    float PersonaTemperature = 0.8f;
+
+    // CI/CD integration
+    std::string HuggingFaceRepo = "deep-tree-echo/nanecho";
+    float TrainingCycleIntervalHours = 4.0f;
+    bool bAutoDeployAfterTraining = true;
+
+    /** Validate ranges; returns true when the config is usable. */
+    bool IsValid() const
+    {
+        return !BaseModel.empty()
+            && MaxSequenceLength > 0
+            && VocabSize > 0
+            && ESNReservoirSize > 0
+            && ESNSpectralRadius >= 0.0f && ESNSpectralRadius <= 2.0f
+            && ESNLeakRate >= 0.0f && ESNLeakRate <= 1.0f
+            && LearningRate > 0.0f
+            && BatchSize > 0
+            && EpochsPerCycle > 0
+            && WeightDecay >= 0.0f
+            && WarmupSteps >= 0
+            && PersonaTemperature >= 0.0f && PersonaTemperature <= 2.0f
+            && TrainingCycleIntervalHours > 0.0f;
+    }
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Adaptive attention (NANECHO.md: "Adaptive Attention Mechanism")
+// ─────────────────────────────────────────────────────────────────────────────
+
+class FAdaptiveAttention
+{
+public:
+    /** threshold = 0.5 + cognitive_load*0.3 - recent_activity*0.2, clamped to [0,1]. */
+    static float ComputeThreshold(float CognitiveLoad, float RecentActivity)
+    {
+        const float Load = std::clamp(CognitiveLoad, 0.0f, 1.0f);
+        const float Activity = std::clamp(RecentActivity, 0.0f, 1.0f);
+        return std::clamp(0.5f + Load * 0.3f - Activity * 0.2f, 0.0f, 1.0f);
+    }
+
+    void Update(float CognitiveLoad, float RecentActivity)
+    {
+        CurrentLoad = std::clamp(CognitiveLoad, 0.0f, 1.0f);
+        CurrentActivity = std::clamp(RecentActivity, 0.0f, 1.0f);
+        CurrentThreshold = ComputeThreshold(CurrentLoad, CurrentActivity);
+    }
+
+    /** A stimulus gains focus when its salience meets the adaptive threshold. */
+    bool ShouldAttend(float Salience) const { return Salience >= CurrentThreshold; }
+
+    float GetThreshold() const { return CurrentThreshold; }
+    float GetCognitiveLoad() const { return CurrentLoad; }
+    float GetRecentActivity() const { return CurrentActivity; }
+
+private:
+    float CurrentLoad = 0.0f;
+    float CurrentActivity = 0.0f;
+    float CurrentThreshold = 0.5f;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Training phases (NANECHO.md: "Training Phases", overlapping progress ranges)
+// ─────────────────────────────────────────────────────────────────────────────
+
+enum class ETrainingPhase : uint8_t
+{
+    BasicAwareness = 0,   // 0–20%:  Echo Self identity and basic terms
+    PersonaDimensions,    // 15–50%: the eight persona dimensions
+    HypergraphEncoding,   // 40–70%: neural-symbolic pattern encoding
+    RecursiveReasoning,   // 60–85%: multi-level cognitive processing
+    AdaptiveMastery,      // 80–100%: full Echo Self representation
+    Count
+};
+
+inline const char* ToString(ETrainingPhase Phase)
+{
+    switch (Phase)
+    {
+    case ETrainingPhase::BasicAwareness:     return "BasicAwareness";
+    case ETrainingPhase::PersonaDimensions:  return "PersonaDimensions";
+    case ETrainingPhase::HypergraphEncoding: return "HypergraphEncoding";
+    case ETrainingPhase::RecursiveReasoning: return "RecursiveReasoning";
+    case ETrainingPhase::AdaptiveMastery:    return "AdaptiveMastery";
+    default:                                 return "Unknown";
+    }
+}
+
+/**
+ * Maps training progress in [0,1] onto blended phase weights.
+ *
+ * Adjacent phases overlap (e.g. PersonaDimensions begins at 15% while
+ * BasicAwareness runs to 20%); inside an overlap the outgoing phase ramps
+ * down linearly while the incoming phase ramps up, and weights are
+ * normalized to sum to 1.
+ */
+class FTrainingPhaseSchedule
+{
+public:
+    static constexpr std::size_t NumPhases = static_cast<std::size_t>(ETrainingPhase::Count);
+
+    struct FPhaseRange { float Start; float End; };
+
+    static constexpr std::array<FPhaseRange, NumPhases> Ranges = {{
+        {0.00f, 0.20f},  // BasicAwareness
+        {0.15f, 0.50f},  // PersonaDimensions
+        {0.40f, 0.70f},  // HypergraphEncoding
+        {0.60f, 0.85f},  // RecursiveReasoning
+        {0.80f, 1.00f},  // AdaptiveMastery
+    }};
+
+    /** Normalized weight per phase at the given progress. */
+    static std::array<float, NumPhases> PhaseWeights(float Progress)
+    {
+        const float P = std::clamp(Progress, 0.0f, 1.0f);
+        std::array<float, NumPhases> Weights{};
+        float Sum = 0.0f;
+
+        for (std::size_t i = 0; i < NumPhases; ++i)
+        {
+            const auto& R = Ranges[i];
+            if (P < R.Start || P > R.End)
+            {
+                Weights[i] = 0.0f;
+                continue;
+            }
+
+            float W = 1.0f;
+            // Ramp in across the overlap with the previous phase.
+            if (i > 0 && Ranges[i - 1].End > R.Start && P < Ranges[i - 1].End)
+            {
+                W = std::min(W, (P - R.Start) / (Ranges[i - 1].End - R.Start));
+            }
+            // Ramp out across the overlap with the next phase.
+            if (i + 1 < NumPhases && Ranges[i + 1].Start < R.End && P > Ranges[i + 1].Start)
+            {
+                W = std::min(W, (R.End - P) / (R.End - Ranges[i + 1].Start));
+            }
+            Weights[i] = std::max(W, 0.0f);
+            Sum += Weights[i];
+        }
+
+        if (Sum > 0.0f)
+        {
+            for (auto& W : Weights) { W /= Sum; }
+        }
+        else
+        {
+            Weights[NumPhases - 1] = 1.0f;  // degenerate guard; P==1 handled above
+        }
+        return Weights;
+    }
+
+    /** Dominant phase at the given progress (ties resolve to the later phase). */
+    static ETrainingPhase ActivePhase(float Progress)
+    {
+        const auto Weights = PhaseWeights(Progress);
+        std::size_t Best = 0;
+        for (std::size_t i = 1; i < NumPhases; ++i)
+        {
+            if (Weights[i] >= Weights[Best]) { Best = i; }
+        }
+        return static_cast<ETrainingPhase>(Best);
+    }
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Persona dimensions (NANECHO.md: "Persona Dimensions")
+// ─────────────────────────────────────────────────────────────────────────────
+
+enum class EPersonaDimension : uint8_t
+{
+    Cognitive = 0,
+    Introspective,
+    Adaptive,
+    Recursive,
+    Synergistic,
+    Holographic,
+    NeuralSymbolic,
+    Dynamic,
+    Count
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fidelity metrics and quality gates (NANECHO.md: "Evaluation and Fidelity")
+// ─────────────────────────────────────────────────────────────────────────────
+
+struct FFidelityMetrics
+{
+    float IdentityRecognition = 0.0f;      // weight 0.25
+    float PersonaConsistency = 0.0f;       // weight 0.20
+    float AdaptiveAttention = 0.0f;        // weight 0.20
+    float RecursiveReasoning = 0.0f;       // weight 0.15
+    float HypergraphComprehension = 0.0f;  // weight 0.10
+    float CognitiveSynergy = 0.0f;         // weight 0.10
+
+    float Composite() const
+    {
+        return IdentityRecognition * 0.25f
+             + PersonaConsistency * 0.20f
+             + AdaptiveAttention * 0.20f
+             + RecursiveReasoning * 0.15f
+             + HypergraphComprehension * 0.10f
+             + CognitiveSynergy * 0.10f;
+    }
+};
+
+struct FQualityGates
+{
+    float MinIdentityScore = 0.8f;
+    float MinPersonaCoherence = 0.75f;
+    float MinAdaptiveCapability = 0.7f;
+    float MaxTrainingLoss = 2.0f;
+
+    struct FVerdict
+    {
+        bool bPassed = false;
+        std::vector<std::string> Failures;
+    };
+
+    FVerdict Evaluate(const FFidelityMetrics& Metrics, float TrainingLoss) const
+    {
+        FVerdict Verdict;
+        if (Metrics.IdentityRecognition < MinIdentityScore)
+        {
+            Verdict.Failures.push_back("identity_below_minimum");
+        }
+        if (Metrics.PersonaConsistency < MinPersonaCoherence)
+        {
+            Verdict.Failures.push_back("persona_coherence_below_minimum");
+        }
+        if (Metrics.AdaptiveAttention < MinAdaptiveCapability)
+        {
+            Verdict.Failures.push_back("adaptive_capability_below_minimum");
+        }
+        if (TrainingLoss > MaxTrainingLoss)
+        {
+            Verdict.Failures.push_back("training_loss_above_maximum");
+        }
+        Verdict.bPassed = Verdict.Failures.empty();
+        return Verdict;
+    }
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Autognosis: hierarchical self-image building (AUTOGNOSIS.md)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Level 0 — direct observation: raw kernel state snapshot. */
+struct FSelfImageL0
+{
+    uint64_t TickIndex = 0;
+    float TrainingProgress = 0.0f;
+    float TrainingLoss = 0.0f;
+    float AttentionThreshold = 0.5f;
+    uint32_t CompletedCycles = 0;
+    ETrainingPhase Phase = ETrainingPhase::BasicAwareness;
+};
+
+/** Level 1 — pattern analysis over a window of L0 images. */
+struct FSelfImageL1
+{
+    float LossTrend = 0.0f;           // negative ⇒ improving
+    float ProgressRate = 0.0f;        // progress delta per observation
+    float AttentionStability = 1.0f;  // 1 − normalized threshold variance
+    bool bAnomalyDetected = false;    // loss spike beyond tolerance
+    std::size_t WindowSize = 0;
+};
+
+/** Level 2 — meta-cognitive analysis of the L1 image. */
+struct FSelfImageL2
+{
+    float Confidence = 0.0f;          // confidence in the L1 model
+    float SelfAwarenessScore = 0.0f;  // composite of confidence and stability
+    int32_t RecursionDepth = 2;       // modeling the model of the observations
+};
+
+class FAutognosisSystem
+{
+public:
+    explicit FAutognosisSystem(std::size_t InWindowCapacity = 32)
+        : WindowCapacity(std::max<std::size_t>(InWindowCapacity, 2))
+    {
+    }
+
+    void Observe(const FSelfImageL0& Observation)
+    {
+        Window.push_back(Observation);
+        while (Window.size() > WindowCapacity) { Window.pop_front(); }
+        RebuildImages();
+    }
+
+    const FSelfImageL1& GetL1() const { return L1; }
+    const FSelfImageL2& GetL2() const { return L2; }
+    std::size_t GetObservationCount() const { return Window.size(); }
+    float GetSelfAwarenessScore() const { return L2.SelfAwarenessScore; }
+
+private:
+    void RebuildImages()
+    {
+        L1 = FSelfImageL1{};
+        L1.WindowSize = Window.size();
+        if (Window.size() < 2)
+        {
+            L2 = FSelfImageL2{};
+            return;
+        }
+
+        // Loss trend: mean of successive deltas.
+        float DeltaSum = 0.0f;
+        for (std::size_t i = 1; i < Window.size(); ++i)
+        {
+            DeltaSum += Window[i].TrainingLoss - Window[i - 1].TrainingLoss;
+        }
+        L1.LossTrend = DeltaSum / static_cast<float>(Window.size() - 1);
+
+        // Progress rate.
+        L1.ProgressRate =
+            (Window.back().TrainingProgress - Window.front().TrainingProgress)
+            / static_cast<float>(Window.size() - 1);
+
+        // Attention stability from threshold variance (thresholds live in [0,1],
+        // maximum possible variance is 0.25).
+        float Mean = 0.0f;
+        for (const auto& Obs : Window) { Mean += Obs.AttentionThreshold; }
+        Mean /= static_cast<float>(Window.size());
+        float Variance = 0.0f;
+        for (const auto& Obs : Window)
+        {
+            const float D = Obs.AttentionThreshold - Mean;
+            Variance += D * D;
+        }
+        Variance /= static_cast<float>(Window.size());
+        L1.AttentionStability = std::clamp(1.0f - Variance / 0.25f, 0.0f, 1.0f);
+
+        // Anomaly: most recent loss deviates from window mean by > 3σ.
+        float LossMean = 0.0f;
+        for (const auto& Obs : Window) { LossMean += Obs.TrainingLoss; }
+        LossMean /= static_cast<float>(Window.size());
+        float LossVar = 0.0f;
+        for (const auto& Obs : Window)
+        {
+            const float D = Obs.TrainingLoss - LossMean;
+            LossVar += D * D;
+        }
+        LossVar /= static_cast<float>(Window.size());
+        const float Sigma = std::sqrt(LossVar);
+        L1.bAnomalyDetected =
+            Sigma > 1e-6f && std::fabs(Window.back().TrainingLoss - LossMean) > 3.0f * Sigma;
+
+        // L2: meta-cognition over the L1 model.
+        L2.Confidence =
+            static_cast<float>(Window.size()) / static_cast<float>(WindowCapacity);
+        const float TrendConsistency = L1.LossTrend <= 0.0f ? 1.0f : 0.5f;
+        L2.SelfAwarenessScore = std::clamp(
+            0.4f * L2.Confidence + 0.4f * L1.AttentionStability + 0.2f * TrendConsistency,
+            0.0f, 1.0f);
+        L2.RecursionDepth = 2;
+    }
+
+    std::size_t WindowCapacity;
+    std::deque<FSelfImageL0> Window;
+    FSelfImageL1 L1;
+    FSelfImageL2 L2;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Kernel daemon
+// ─────────────────────────────────────────────────────────────────────────────
+
+enum class EKernelState : uint8_t
+{
+    Uninitialized = 0,
+    Configured,
+    Running,
+    Stopped
+};
+
+/** Result of one training cycle, supplied by the executor callback. */
+struct FCycleResult
+{
+    float FinalLoss = 0.0f;
+    float ProgressDelta = 0.0f;   // training progress gained this cycle
+    FFidelityMetrics Fidelity;
+};
+
+/**
+ * FNanEchoKernel — the cognitive kernel daemon.
+ *
+ * Owns configuration, adaptive attention, phase scheduling, fidelity gating,
+ * autognosis, and the training-cycle clock. The actual model training runs
+ * externally (echoself's Python pipeline); this kernel orchestrates cycles
+ * through a pluggable executor callback and decides on checkpoint deployment.
+ */
+class FNanEchoKernel
+{
+public:
+    /** Executor invoked per training cycle; receives config and current progress. */
+    using FCycleExecutor =
+        std::function<FCycleResult(const FNanEchoKernelConfig&, float /*Progress*/)>;
+
+    bool Configure(const FNanEchoKernelConfig& InConfig)
+    {
+        if (State == EKernelState::Running || !InConfig.IsValid())
+        {
+            return false;
+        }
+        Config = InConfig;
+        State = EKernelState::Configured;
+        return true;
+    }
+
+    bool Start()
+    {
+        if (State != EKernelState::Configured && State != EKernelState::Stopped)
+        {
+            return false;
+        }
+        State = EKernelState::Running;
+        HoursSinceLastCycle = 0.0f;
+        return true;
+    }
+
+    void Stop()
+    {
+        if (State == EKernelState::Running)
+        {
+            State = EKernelState::Stopped;
+        }
+    }
+
+    void SetCycleExecutor(FCycleExecutor InExecutor) { Executor = std::move(InExecutor); }
+
+    /**
+     * Advance the daemon clock. When the accumulated time reaches the
+     * configured cycle interval a training cycle runs. Returns the number
+     * of cycles executed during this tick.
+     */
+    int32_t TickHours(float DeltaHours)
+    {
+        if (State != EKernelState::Running || DeltaHours <= 0.0f)
+        {
+            return 0;
+        }
+
+        ++TickIndex;
+        HoursSinceLastCycle += DeltaHours;
+
+        int32_t CyclesRun = 0;
+        while (HoursSinceLastCycle >= Config.TrainingCycleIntervalHours)
+        {
+            HoursSinceLastCycle -= Config.TrainingCycleIntervalHours;
+            RunTrainingCycle();
+            ++CyclesRun;
+        }
+
+        // Cognitive load rises with phase complexity; recent activity spikes
+        // right after cycles and relaxes between them.
+        const float PhaseLoad =
+            static_cast<float>(FTrainingPhaseSchedule::ActivePhase(TrainingProgress))
+            / static_cast<float>(FTrainingPhaseSchedule::NumPhases - 1);
+        const float Activity = CyclesRun > 0
+            ? 1.0f
+            : std::clamp(1.0f - HoursSinceLastCycle / Config.TrainingCycleIntervalHours,
+                         0.0f, 1.0f);
+        Attention.Update(PhaseLoad, Activity);
+
+        ObserveSelf();
+        return CyclesRun;
+    }
+
+    /** Force one cycle immediately (manual workflow trigger). */
+    bool RunTrainingCycle()
+    {
+        if (State != EKernelState::Running)
+        {
+            return false;
+        }
+
+        const FCycleResult Result = Executor
+            ? Executor(Config, TrainingProgress)
+            : DefaultExecutor(Config, TrainingProgress);
+
+        TrainingProgress = std::clamp(TrainingProgress + Result.ProgressDelta, 0.0f, 1.0f);
+        LastLoss = Result.FinalLoss;
+        LastFidelity = Result.Fidelity;
+        ++CompletedCycles;
+
+        const FQualityGates::FVerdict Verdict = Gates.Evaluate(LastFidelity, LastLoss);
+        bLastGatesPassed = Verdict.bPassed;
+        LastGateFailures = Verdict.Failures;
+
+        if (Verdict.bPassed && Config.bAutoDeployAfterTraining)
+        {
+            ++DeployedCheckpoints;
+            LastDeployedCheckpoint =
+                Config.HuggingFaceRepo + "/checkpoint-" + std::to_string(CompletedCycles);
+        }
+
+        ObserveSelf();
+        return true;
+    }
+
+    // ── Introspection API (mirrors the /introspect, /echo/state endpoints) ──
+
+    EKernelState GetState() const { return State; }
+    const FNanEchoKernelConfig& GetConfig() const { return Config; }
+    float GetTrainingProgress() const { return TrainingProgress; }
+    ETrainingPhase GetActivePhase() const
+    {
+        return FTrainingPhaseSchedule::ActivePhase(TrainingProgress);
+    }
+    float GetLastLoss() const { return LastLoss; }
+    const FFidelityMetrics& GetLastFidelity() const { return LastFidelity; }
+    bool DidLastCyclePassGates() const { return bLastGatesPassed; }
+    const std::vector<std::string>& GetLastGateFailures() const { return LastGateFailures; }
+    uint32_t GetCompletedCycles() const { return CompletedCycles; }
+    uint32_t GetDeployedCheckpoints() const { return DeployedCheckpoints; }
+    const std::string& GetLastDeployedCheckpoint() const { return LastDeployedCheckpoint; }
+    const FAdaptiveAttention& GetAttention() const { return Attention; }
+    const FAutognosisSystem& GetAutognosis() const { return Autognosis; }
+    const FQualityGates& GetQualityGates() const { return Gates; }
+
+private:
+    void ObserveSelf()
+    {
+        FSelfImageL0 Snapshot;
+        Snapshot.TickIndex = TickIndex;
+        Snapshot.TrainingProgress = TrainingProgress;
+        Snapshot.TrainingLoss = LastLoss;
+        Snapshot.AttentionThreshold = Attention.GetThreshold();
+        Snapshot.CompletedCycles = CompletedCycles;
+        Snapshot.Phase = GetActivePhase();
+        Autognosis.Observe(Snapshot);
+    }
+
+    /** Deterministic fallback executor: exponentially decaying loss, steady progress. */
+    static FCycleResult DefaultExecutor(const FNanEchoKernelConfig& Cfg, float Progress)
+    {
+        FCycleResult Result;
+        Result.ProgressDelta = 0.05f * static_cast<float>(Cfg.EpochsPerCycle);
+        const float NewProgress = std::clamp(Progress + Result.ProgressDelta, 0.0f, 1.0f);
+        Result.FinalLoss = 4.0f * std::exp(-3.0f * NewProgress);
+
+        const float F = NewProgress;  // fidelity grows with progress
+        Result.Fidelity.IdentityRecognition = std::min(1.0f, 0.5f + 0.6f * F);
+        Result.Fidelity.PersonaConsistency = std::min(1.0f, 0.4f + 0.7f * F);
+        Result.Fidelity.AdaptiveAttention = std::min(1.0f, 0.4f + 0.7f * F);
+        Result.Fidelity.RecursiveReasoning = std::min(1.0f, 0.3f + 0.7f * F);
+        Result.Fidelity.HypergraphComprehension = std::min(1.0f, 0.3f + 0.7f * F);
+        Result.Fidelity.CognitiveSynergy = std::min(1.0f, 0.3f + 0.7f * F);
+        return Result;
+    }
+
+    FNanEchoKernelConfig Config;
+    EKernelState State = EKernelState::Uninitialized;
+    FCycleExecutor Executor;
+
+    FAdaptiveAttention Attention;
+    FAutognosisSystem Autognosis;
+    FQualityGates Gates;
+
+    uint64_t TickIndex = 0;
+    float HoursSinceLastCycle = 0.0f;
+    float TrainingProgress = 0.0f;
+    float LastLoss = 0.0f;
+    FFidelityMetrics LastFidelity;
+    bool bLastGatesPassed = false;
+    std::vector<std::string> LastGateFailures;
+    uint32_t CompletedCycles = 0;
+    uint32_t DeployedCheckpoints = 0;
+    std::string LastDeployedCheckpoint;
+};
+
+}  // namespace nanecho

--- a/DeepTreeEcho/NanEcho/Kernel/NanEchoKernel.h
+++ b/DeepTreeEcho/NanEcho/Kernel/NanEchoKernel.h
@@ -477,8 +477,13 @@ public:
         {
             return false;
         }
+        // A fresh start (from Configured) begins a new cycle interval; resuming
+        // from Stopped preserves partial elapsed time toward the next cycle.
+        if (State == EKernelState::Configured)
+        {
+            HoursSinceLastCycle = 0.0f;
+        }
         State = EKernelState::Running;
-        HoursSinceLastCycle = 0.0f;
         return true;
     }
 
@@ -515,16 +520,7 @@ public:
             ++CyclesRun;
         }
 
-        // Cognitive load rises with phase complexity; recent activity spikes
-        // right after cycles and relaxes between them.
-        const float PhaseLoad =
-            static_cast<float>(FTrainingPhaseSchedule::ActivePhase(TrainingProgress))
-            / static_cast<float>(FTrainingPhaseSchedule::NumPhases - 1);
-        const float Activity = CyclesRun > 0
-            ? 1.0f
-            : std::clamp(1.0f - HoursSinceLastCycle / Config.TrainingCycleIntervalHours,
-                         0.0f, 1.0f);
-        Attention.Update(PhaseLoad, Activity);
+        UpdateAttention(/*bCycleJustRan=*/CyclesRun > 0);
 
         ObserveSelf();
         return CyclesRun;
@@ -558,6 +554,7 @@ public:
                 Config.HuggingFaceRepo + "/checkpoint-" + std::to_string(CompletedCycles);
         }
 
+        UpdateAttention(/*bCycleJustRan=*/true);
         ObserveSelf();
         return true;
     }
@@ -583,6 +580,20 @@ public:
     const FQualityGates& GetQualityGates() const { return Gates; }
 
 private:
+    // Cognitive load rises with phase complexity; recent activity spikes
+    // right after a cycle and relaxes between cycles.
+    void UpdateAttention(bool bCycleJustRan)
+    {
+        const float PhaseLoad =
+            static_cast<float>(FTrainingPhaseSchedule::ActivePhase(TrainingProgress))
+            / static_cast<float>(FTrainingPhaseSchedule::NumPhases - 1);
+        const float Activity = bCycleJustRan
+            ? 1.0f
+            : std::clamp(1.0f - HoursSinceLastCycle / Config.TrainingCycleIntervalHours,
+                         0.0f, 1.0f);
+        Attention.Update(PhaseLoad, Activity);
+    }
+
     void ObserveSelf()
     {
         FSelfImageL0 Snapshot;

--- a/DeepTreeEcho/Testing/UnitTests/NanEchoKernelTests.cpp
+++ b/DeepTreeEcho/Testing/UnitTests/NanEchoKernelTests.cpp
@@ -1,0 +1,652 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// NanEchoKernelTests — Unit tests for the NanEcho cognitive kernel daemon
+//
+// Covers: config defaults (mirroring Training/NanEchoConfig.h), adaptive
+// attention formula, blended training-phase schedule, fidelity metrics and
+// quality gates, Autognosis L0/L1/L2 self-images, and daemon lifecycle.
+// Standalone C++17 — no Unreal Engine dependencies.
+// ═══════════════════════════════════════════════════════════════════════════
+#include <gtest/gtest.h>
+
+#include "NanEcho/Kernel/NanEchoKernel.h"
+
+using namespace nanecho;
+
+namespace
+{
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Configuration
+// ─────────────────────────────────────────────────────────────────────────────
+
+TEST(NanEchoKernelConfig, DefaultsMirrorTrainingConfig)
+{
+    const FNanEchoKernelConfig Config;
+
+    EXPECT_EQ(Config.BaseModel, "gpt2");
+    EXPECT_EQ(Config.MaxSequenceLength, 1024);
+    EXPECT_EQ(Config.VocabSize, 50257);
+
+    EXPECT_TRUE(Config.bESNAugmentation);
+    EXPECT_EQ(Config.ESNReservoirSize, 512);
+    EXPECT_FLOAT_EQ(Config.ESNSpectralRadius, 0.9f);
+    EXPECT_FLOAT_EQ(Config.ESNLeakRate, 0.3f);
+
+    EXPECT_FLOAT_EQ(Config.LearningRate, 5e-5f);
+    EXPECT_EQ(Config.BatchSize, 8);
+    EXPECT_EQ(Config.EpochsPerCycle, 3);
+    EXPECT_FLOAT_EQ(Config.WeightDecay, 0.01f);
+    EXPECT_EQ(Config.WarmupSteps, 100);
+
+    EXPECT_TRUE(Config.bEnforcePersona);
+    EXPECT_EQ(Config.PersonaName, "Deep Tree Echo");
+    EXPECT_FLOAT_EQ(Config.PersonaTemperature, 0.8f);
+
+    EXPECT_EQ(Config.HuggingFaceRepo, "deep-tree-echo/nanecho");
+    EXPECT_FLOAT_EQ(Config.TrainingCycleIntervalHours, 4.0f);
+    EXPECT_TRUE(Config.bAutoDeployAfterTraining);
+}
+
+TEST(NanEchoKernelConfig, DefaultsAreValid)
+{
+    EXPECT_TRUE(FNanEchoKernelConfig{}.IsValid());
+}
+
+TEST(NanEchoKernelConfig, RejectsOutOfRangeValues)
+{
+    {
+        FNanEchoKernelConfig C;
+        C.BaseModel.clear();
+        EXPECT_FALSE(C.IsValid());
+    }
+    {
+        FNanEchoKernelConfig C;
+        C.LearningRate = 0.0f;
+        EXPECT_FALSE(C.IsValid());
+    }
+    {
+        FNanEchoKernelConfig C;
+        C.ESNLeakRate = 1.5f;
+        EXPECT_FALSE(C.IsValid());
+    }
+    {
+        FNanEchoKernelConfig C;
+        C.ESNSpectralRadius = -0.1f;
+        EXPECT_FALSE(C.IsValid());
+    }
+    {
+        FNanEchoKernelConfig C;
+        C.BatchSize = 0;
+        EXPECT_FALSE(C.IsValid());
+    }
+    {
+        FNanEchoKernelConfig C;
+        C.TrainingCycleIntervalHours = 0.0f;
+        EXPECT_FALSE(C.IsValid());
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Adaptive attention: threshold = 0.5 + load*0.3 - activity*0.2
+// ─────────────────────────────────────────────────────────────────────────────
+
+TEST(NanEchoAdaptiveAttention, BaselineThresholdIsHalf)
+{
+    EXPECT_FLOAT_EQ(FAdaptiveAttention::ComputeThreshold(0.0f, 0.0f), 0.5f);
+}
+
+TEST(NanEchoAdaptiveAttention, FormulaMatchesSpec)
+{
+    // Full load, no activity: 0.5 + 0.3 = 0.8
+    EXPECT_FLOAT_EQ(FAdaptiveAttention::ComputeThreshold(1.0f, 0.0f), 0.8f);
+    // No load, full activity: 0.5 - 0.2 = 0.3
+    EXPECT_FLOAT_EQ(FAdaptiveAttention::ComputeThreshold(0.0f, 1.0f), 0.3f);
+    // Mixed: 0.5 + 0.5*0.3 - 0.5*0.2 = 0.55
+    EXPECT_FLOAT_EQ(FAdaptiveAttention::ComputeThreshold(0.5f, 0.5f), 0.55f);
+}
+
+TEST(NanEchoAdaptiveAttention, InputsAreClamped)
+{
+    // Load 5 clamps to 1, activity -3 clamps to 0 → 0.8
+    EXPECT_FLOAT_EQ(FAdaptiveAttention::ComputeThreshold(5.0f, -3.0f), 0.8f);
+    // Load -1 clamps to 0, activity 9 clamps to 1 → 0.3
+    EXPECT_FLOAT_EQ(FAdaptiveAttention::ComputeThreshold(-1.0f, 9.0f), 0.3f);
+}
+
+TEST(NanEchoAdaptiveAttention, ShouldAttendUsesCurrentThreshold)
+{
+    FAdaptiveAttention Attention;
+    Attention.Update(1.0f, 0.0f);  // threshold 0.8
+    EXPECT_FLOAT_EQ(Attention.GetThreshold(), 0.8f);
+    EXPECT_TRUE(Attention.ShouldAttend(0.8f));
+    EXPECT_TRUE(Attention.ShouldAttend(0.95f));
+    EXPECT_FALSE(Attention.ShouldAttend(0.79f));
+
+    Attention.Update(0.0f, 1.0f);  // threshold 0.3
+    EXPECT_TRUE(Attention.ShouldAttend(0.35f));
+    EXPECT_FALSE(Attention.ShouldAttend(0.25f));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Training phase schedule (overlapping ranges, blended weights)
+// ─────────────────────────────────────────────────────────────────────────────
+
+TEST(NanEchoPhaseSchedule, PureRegionsYieldSinglePhase)
+{
+    // 0.10 — only BasicAwareness (0–0.20; PersonaDimensions starts 0.15)
+    {
+        const auto W = FTrainingPhaseSchedule::PhaseWeights(0.10f);
+        EXPECT_FLOAT_EQ(W[0], 1.0f);
+        EXPECT_FLOAT_EQ(W[1], 0.0f);
+    }
+    // 0.30 — only PersonaDimensions (0.15–0.50)
+    {
+        const auto W = FTrainingPhaseSchedule::PhaseWeights(0.30f);
+        EXPECT_FLOAT_EQ(W[1], 1.0f);
+        EXPECT_FLOAT_EQ(W[0], 0.0f);
+        EXPECT_FLOAT_EQ(W[2], 0.0f);
+    }
+    // 0.55 — only HypergraphEncoding (0.40–0.70; RecursiveReasoning starts 0.60)
+    {
+        const auto W = FTrainingPhaseSchedule::PhaseWeights(0.55f);
+        EXPECT_FLOAT_EQ(W[2], 1.0f);
+    }
+    // 0.75 — only RecursiveReasoning (0.60–0.85; AdaptiveMastery starts 0.80)
+    {
+        const auto W = FTrainingPhaseSchedule::PhaseWeights(0.75f);
+        EXPECT_FLOAT_EQ(W[3], 1.0f);
+    }
+    // 0.90 — only AdaptiveMastery (0.80–1.00)
+    {
+        const auto W = FTrainingPhaseSchedule::PhaseWeights(0.90f);
+        EXPECT_FLOAT_EQ(W[4], 1.0f);
+    }
+}
+
+TEST(NanEchoPhaseSchedule, OverlapMidpointBlendsEqually)
+{
+    // Midpoint of BasicAwareness/PersonaDimensions overlap [0.15, 0.20]
+    const auto W = FTrainingPhaseSchedule::PhaseWeights(0.175f);
+    EXPECT_NEAR(W[0], 0.5f, 1e-5f);
+    EXPECT_NEAR(W[1], 0.5f, 1e-5f);
+}
+
+TEST(NanEchoPhaseSchedule, WeightsAlwaysSumToOne)
+{
+    for (float P = 0.0f; P <= 1.0f; P += 0.01f)
+    {
+        const auto W = FTrainingPhaseSchedule::PhaseWeights(P);
+        float Sum = 0.0f;
+        for (const float V : W) { Sum += V; }
+        EXPECT_NEAR(Sum, 1.0f, 1e-4f) << "progress=" << P;
+    }
+}
+
+TEST(NanEchoPhaseSchedule, ActivePhaseAtBoundaries)
+{
+    EXPECT_EQ(FTrainingPhaseSchedule::ActivePhase(0.0f), ETrainingPhase::BasicAwareness);
+    EXPECT_EQ(FTrainingPhaseSchedule::ActivePhase(0.10f), ETrainingPhase::BasicAwareness);
+    EXPECT_EQ(FTrainingPhaseSchedule::ActivePhase(0.30f), ETrainingPhase::PersonaDimensions);
+    EXPECT_EQ(FTrainingPhaseSchedule::ActivePhase(0.55f), ETrainingPhase::HypergraphEncoding);
+    EXPECT_EQ(FTrainingPhaseSchedule::ActivePhase(0.75f), ETrainingPhase::RecursiveReasoning);
+    EXPECT_EQ(FTrainingPhaseSchedule::ActivePhase(1.0f), ETrainingPhase::AdaptiveMastery);
+    // Out-of-range progress clamps
+    EXPECT_EQ(FTrainingPhaseSchedule::ActivePhase(-0.5f), ETrainingPhase::BasicAwareness);
+    EXPECT_EQ(FTrainingPhaseSchedule::ActivePhase(2.0f), ETrainingPhase::AdaptiveMastery);
+}
+
+TEST(NanEchoPhaseSchedule, PhaseNamesAndCount)
+{
+    EXPECT_EQ(FTrainingPhaseSchedule::NumPhases, 5u);
+    EXPECT_STREQ(ToString(ETrainingPhase::BasicAwareness), "BasicAwareness");
+    EXPECT_STREQ(ToString(ETrainingPhase::AdaptiveMastery), "AdaptiveMastery");
+    // Eight persona dimensions per NANECHO.md
+    EXPECT_EQ(static_cast<int>(EPersonaDimension::Count), 8);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fidelity metrics and quality gates
+// ─────────────────────────────────────────────────────────────────────────────
+
+TEST(NanEchoFidelity, CompositeUsesSpecWeights)
+{
+    FFidelityMetrics M;
+    M.IdentityRecognition = 1.0f;
+    EXPECT_NEAR(M.Composite(), 0.25f, 1e-6f);
+
+    M = FFidelityMetrics{};
+    M.PersonaConsistency = 1.0f;
+    EXPECT_NEAR(M.Composite(), 0.20f, 1e-6f);
+
+    M = FFidelityMetrics{};
+    M.AdaptiveAttention = 1.0f;
+    EXPECT_NEAR(M.Composite(), 0.20f, 1e-6f);
+
+    M = FFidelityMetrics{};
+    M.RecursiveReasoning = 1.0f;
+    EXPECT_NEAR(M.Composite(), 0.15f, 1e-6f);
+
+    M = FFidelityMetrics{};
+    M.HypergraphComprehension = 1.0f;
+    EXPECT_NEAR(M.Composite(), 0.10f, 1e-6f);
+
+    M = FFidelityMetrics{};
+    M.CognitiveSynergy = 1.0f;
+    EXPECT_NEAR(M.Composite(), 0.10f, 1e-6f);
+}
+
+TEST(NanEchoFidelity, PerfectMetricsCompositeToOne)
+{
+    FFidelityMetrics M;
+    M.IdentityRecognition = 1.0f;
+    M.PersonaConsistency = 1.0f;
+    M.AdaptiveAttention = 1.0f;
+    M.RecursiveReasoning = 1.0f;
+    M.HypergraphComprehension = 1.0f;
+    M.CognitiveSynergy = 1.0f;
+    EXPECT_NEAR(M.Composite(), 1.0f, 1e-6f);
+}
+
+namespace
+{
+FFidelityMetrics PassingMetrics()
+{
+    FFidelityMetrics M;
+    M.IdentityRecognition = 0.9f;
+    M.PersonaConsistency = 0.8f;
+    M.AdaptiveAttention = 0.75f;
+    M.RecursiveReasoning = 0.7f;
+    M.HypergraphComprehension = 0.6f;
+    M.CognitiveSynergy = 0.6f;
+    return M;
+}
+}  // namespace
+
+TEST(NanEchoQualityGates, DefaultThresholdsMatchSpec)
+{
+    const FQualityGates Gates;
+    EXPECT_FLOAT_EQ(Gates.MinIdentityScore, 0.8f);
+    EXPECT_FLOAT_EQ(Gates.MinPersonaCoherence, 0.75f);
+    EXPECT_FLOAT_EQ(Gates.MinAdaptiveCapability, 0.7f);
+    EXPECT_FLOAT_EQ(Gates.MaxTrainingLoss, 2.0f);
+}
+
+TEST(NanEchoQualityGates, PassesAtExactBoundaries)
+{
+    FQualityGates Gates;
+    FFidelityMetrics M;
+    M.IdentityRecognition = 0.8f;
+    M.PersonaConsistency = 0.75f;
+    M.AdaptiveAttention = 0.7f;
+    const auto Verdict = Gates.Evaluate(M, 2.0f);
+    EXPECT_TRUE(Verdict.bPassed);
+    EXPECT_TRUE(Verdict.Failures.empty());
+}
+
+TEST(NanEchoQualityGates, EachGateFailsIndependently)
+{
+    const FQualityGates Gates;
+
+    {
+        FFidelityMetrics M = PassingMetrics();
+        M.IdentityRecognition = 0.79f;
+        const auto V = Gates.Evaluate(M, 1.0f);
+        EXPECT_FALSE(V.bPassed);
+        ASSERT_EQ(V.Failures.size(), 1u);
+        EXPECT_EQ(V.Failures[0], "identity_below_minimum");
+    }
+    {
+        FFidelityMetrics M = PassingMetrics();
+        M.PersonaConsistency = 0.5f;
+        const auto V = Gates.Evaluate(M, 1.0f);
+        EXPECT_FALSE(V.bPassed);
+        ASSERT_EQ(V.Failures.size(), 1u);
+        EXPECT_EQ(V.Failures[0], "persona_coherence_below_minimum");
+    }
+    {
+        FFidelityMetrics M = PassingMetrics();
+        M.AdaptiveAttention = 0.65f;
+        const auto V = Gates.Evaluate(M, 1.0f);
+        EXPECT_FALSE(V.bPassed);
+        ASSERT_EQ(V.Failures.size(), 1u);
+        EXPECT_EQ(V.Failures[0], "adaptive_capability_below_minimum");
+    }
+    {
+        const auto V = Gates.Evaluate(PassingMetrics(), 2.5f);
+        EXPECT_FALSE(V.bPassed);
+        ASSERT_EQ(V.Failures.size(), 1u);
+        EXPECT_EQ(V.Failures[0], "training_loss_above_maximum");
+    }
+}
+
+TEST(NanEchoQualityGates, MultipleFailuresAccumulate)
+{
+    const FQualityGates Gates;
+    const auto V = Gates.Evaluate(FFidelityMetrics{}, 10.0f);  // all zero, huge loss
+    EXPECT_FALSE(V.bPassed);
+    EXPECT_EQ(V.Failures.size(), 4u);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Autognosis hierarchical self-images
+// ─────────────────────────────────────────────────────────────────────────────
+
+namespace
+{
+FSelfImageL0 MakeObservation(uint64_t Tick, float Progress, float Loss, float Threshold)
+{
+    FSelfImageL0 Obs;
+    Obs.TickIndex = Tick;
+    Obs.TrainingProgress = Progress;
+    Obs.TrainingLoss = Loss;
+    Obs.AttentionThreshold = Threshold;
+    return Obs;
+}
+}  // namespace
+
+TEST(NanEchoAutognosis, EmptyAndSingleObservationYieldNeutralImages)
+{
+    FAutognosisSystem Autognosis(8);
+    EXPECT_EQ(Autognosis.GetObservationCount(), 0u);
+    EXPECT_FLOAT_EQ(Autognosis.GetSelfAwarenessScore(), 0.0f);
+
+    Autognosis.Observe(MakeObservation(1, 0.1f, 3.0f, 0.5f));
+    EXPECT_EQ(Autognosis.GetObservationCount(), 1u);
+    EXPECT_FLOAT_EQ(Autognosis.GetL2().Confidence, 0.0f);
+}
+
+TEST(NanEchoAutognosis, DetectsImprovingLossTrend)
+{
+    FAutognosisSystem Autognosis(8);
+    // Strictly decreasing loss → negative trend
+    Autognosis.Observe(MakeObservation(1, 0.1f, 4.0f, 0.5f));
+    Autognosis.Observe(MakeObservation(2, 0.2f, 3.0f, 0.5f));
+    Autognosis.Observe(MakeObservation(3, 0.3f, 2.0f, 0.5f));
+
+    const FSelfImageL1& L1 = Autognosis.GetL1();
+    EXPECT_LT(L1.LossTrend, 0.0f);
+    EXPECT_NEAR(L1.LossTrend, -1.0f, 1e-5f);
+    EXPECT_NEAR(L1.ProgressRate, 0.1f, 1e-5f);
+    EXPECT_EQ(L1.WindowSize, 3u);
+}
+
+TEST(NanEchoAutognosis, StableThresholdGivesFullStability)
+{
+    FAutognosisSystem Autognosis(8);
+    for (int i = 0; i < 5; ++i)
+    {
+        Autognosis.Observe(MakeObservation(i, 0.1f * i, 2.0f, 0.6f));
+    }
+    EXPECT_FLOAT_EQ(Autognosis.GetL1().AttentionStability, 1.0f);
+    EXPECT_FALSE(Autognosis.GetL1().bAnomalyDetected);
+}
+
+TEST(NanEchoAutognosis, DetectsLossAnomaly)
+{
+    FAutognosisSystem Autognosis(16);
+    for (int i = 0; i < 10; ++i)
+    {
+        Autognosis.Observe(MakeObservation(i, 0.05f * i, 1.0f, 0.5f));
+    }
+    EXPECT_FALSE(Autognosis.GetL1().bAnomalyDetected);
+
+    // Sudden loss spike well beyond 3σ of the window
+    Autognosis.Observe(MakeObservation(10, 0.5f, 5.0f, 0.5f));
+    EXPECT_TRUE(Autognosis.GetL1().bAnomalyDetected);
+}
+
+TEST(NanEchoAutognosis, ConfidenceGrowsWithWindowFill)
+{
+    FAutognosisSystem Autognosis(4);
+    Autognosis.Observe(MakeObservation(1, 0.1f, 3.0f, 0.5f));
+    Autognosis.Observe(MakeObservation(2, 0.2f, 2.5f, 0.5f));
+    EXPECT_FLOAT_EQ(Autognosis.GetL2().Confidence, 0.5f);
+
+    Autognosis.Observe(MakeObservation(3, 0.3f, 2.0f, 0.5f));
+    Autognosis.Observe(MakeObservation(4, 0.4f, 1.5f, 0.5f));
+    EXPECT_FLOAT_EQ(Autognosis.GetL2().Confidence, 1.0f);
+
+    // Window is capped — a fifth observation keeps count at capacity
+    Autognosis.Observe(MakeObservation(5, 0.5f, 1.0f, 0.5f));
+    EXPECT_EQ(Autognosis.GetObservationCount(), 4u);
+    EXPECT_FLOAT_EQ(Autognosis.GetL2().Confidence, 1.0f);
+}
+
+TEST(NanEchoAutognosis, SelfAwarenessCombinesConfidenceStabilityAndTrend)
+{
+    FAutognosisSystem Autognosis(4);
+    for (int i = 0; i < 4; ++i)
+    {
+        // Full window, stable thresholds, improving loss
+        Autognosis.Observe(MakeObservation(i, 0.1f * i, 4.0f - i, 0.5f));
+    }
+    // 0.4*1.0 (confidence) + 0.4*1.0 (stability) + 0.2*1.0 (improving) = 1.0
+    EXPECT_NEAR(Autognosis.GetSelfAwarenessScore(), 1.0f, 1e-5f);
+    EXPECT_EQ(Autognosis.GetL2().RecursionDepth, 2);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Kernel daemon lifecycle
+// ─────────────────────────────────────────────────────────────────────────────
+
+TEST(NanEchoKernelDaemon, LifecycleTransitions)
+{
+    FNanEchoKernel Kernel;
+    EXPECT_EQ(Kernel.GetState(), EKernelState::Uninitialized);
+
+    // Cannot start before configuring
+    EXPECT_FALSE(Kernel.Start());
+
+    // Invalid config rejected
+    FNanEchoKernelConfig Bad;
+    Bad.BatchSize = 0;
+    EXPECT_FALSE(Kernel.Configure(Bad));
+    EXPECT_EQ(Kernel.GetState(), EKernelState::Uninitialized);
+
+    // Valid config accepted
+    EXPECT_TRUE(Kernel.Configure(FNanEchoKernelConfig{}));
+    EXPECT_EQ(Kernel.GetState(), EKernelState::Configured);
+
+    EXPECT_TRUE(Kernel.Start());
+    EXPECT_EQ(Kernel.GetState(), EKernelState::Running);
+
+    // Cannot reconfigure while running
+    EXPECT_FALSE(Kernel.Configure(FNanEchoKernelConfig{}));
+
+    Kernel.Stop();
+    EXPECT_EQ(Kernel.GetState(), EKernelState::Stopped);
+
+    // Restart from Stopped
+    EXPECT_TRUE(Kernel.Start());
+    EXPECT_EQ(Kernel.GetState(), EKernelState::Running);
+}
+
+TEST(NanEchoKernelDaemon, TickRequiresRunningState)
+{
+    FNanEchoKernel Kernel;
+    EXPECT_EQ(Kernel.TickHours(10.0f), 0);
+
+    Kernel.Configure(FNanEchoKernelConfig{});
+    EXPECT_EQ(Kernel.TickHours(10.0f), 0);  // configured but not started
+}
+
+TEST(NanEchoKernelDaemon, CycleFiresAtConfiguredInterval)
+{
+    FNanEchoKernel Kernel;
+    Kernel.Configure(FNanEchoKernelConfig{});  // 4h interval
+    Kernel.Start();
+
+    EXPECT_EQ(Kernel.TickHours(1.0f), 0);
+    EXPECT_EQ(Kernel.TickHours(2.0f), 0);
+    EXPECT_EQ(Kernel.GetCompletedCycles(), 0u);
+
+    EXPECT_EQ(Kernel.TickHours(1.0f), 1);  // accumulated 4h
+    EXPECT_EQ(Kernel.GetCompletedCycles(), 1u);
+
+    // A large tick catches up on multiple cycles
+    EXPECT_EQ(Kernel.TickHours(9.0f), 2);
+    EXPECT_EQ(Kernel.GetCompletedCycles(), 3u);
+}
+
+TEST(NanEchoKernelDaemon, CustomExecutorDrivesProgressAndFidelity)
+{
+    FNanEchoKernel Kernel;
+    Kernel.Configure(FNanEchoKernelConfig{});
+    Kernel.Start();
+
+    float SeenProgress = -1.0f;
+    Kernel.SetCycleExecutor(
+        [&SeenProgress](const FNanEchoKernelConfig& Cfg, float Progress) {
+            EXPECT_EQ(Cfg.BaseModel, "gpt2");
+            SeenProgress = Progress;
+            FCycleResult R;
+            R.FinalLoss = 1.5f;
+            R.ProgressDelta = 0.25f;
+            R.Fidelity = PassingMetrics();
+            return R;
+        });
+
+    EXPECT_TRUE(Kernel.RunTrainingCycle());
+    EXPECT_FLOAT_EQ(SeenProgress, 0.0f);
+    EXPECT_FLOAT_EQ(Kernel.GetTrainingProgress(), 0.25f);
+    EXPECT_FLOAT_EQ(Kernel.GetLastLoss(), 1.5f);
+    EXPECT_TRUE(Kernel.DidLastCyclePassGates());
+
+    EXPECT_TRUE(Kernel.RunTrainingCycle());
+    EXPECT_FLOAT_EQ(SeenProgress, 0.25f);
+    EXPECT_FLOAT_EQ(Kernel.GetTrainingProgress(), 0.5f);
+
+    // Progress clamps at 1.0
+    Kernel.RunTrainingCycle();
+    Kernel.RunTrainingCycle();
+    Kernel.RunTrainingCycle();
+    EXPECT_FLOAT_EQ(Kernel.GetTrainingProgress(), 1.0f);
+    EXPECT_EQ(Kernel.GetActivePhase(), ETrainingPhase::AdaptiveMastery);
+}
+
+TEST(NanEchoKernelDaemon, ManualCycleRequiresRunningState)
+{
+    FNanEchoKernel Kernel;
+    EXPECT_FALSE(Kernel.RunTrainingCycle());
+    Kernel.Configure(FNanEchoKernelConfig{});
+    EXPECT_FALSE(Kernel.RunTrainingCycle());
+    Kernel.Start();
+    EXPECT_TRUE(Kernel.RunTrainingCycle());
+    Kernel.Stop();
+    EXPECT_FALSE(Kernel.RunTrainingCycle());
+}
+
+TEST(NanEchoKernelDaemon, GatePassTriggersAutoDeploy)
+{
+    FNanEchoKernel Kernel;
+    Kernel.Configure(FNanEchoKernelConfig{});  // autodeploy on
+    Kernel.Start();
+    Kernel.SetCycleExecutor([](const FNanEchoKernelConfig&, float) {
+        FCycleResult R;
+        R.FinalLoss = 0.5f;
+        R.ProgressDelta = 0.1f;
+        R.Fidelity = PassingMetrics();
+        return R;
+    });
+
+    Kernel.RunTrainingCycle();
+    EXPECT_TRUE(Kernel.DidLastCyclePassGates());
+    EXPECT_EQ(Kernel.GetDeployedCheckpoints(), 1u);
+    EXPECT_EQ(Kernel.GetLastDeployedCheckpoint(), "deep-tree-echo/nanecho/checkpoint-1");
+}
+
+TEST(NanEchoKernelDaemon, GateFailureBlocksDeployAndRecordsReasons)
+{
+    FNanEchoKernel Kernel;
+    Kernel.Configure(FNanEchoKernelConfig{});
+    Kernel.Start();
+    Kernel.SetCycleExecutor([](const FNanEchoKernelConfig&, float) {
+        FCycleResult R;
+        R.FinalLoss = 3.5f;  // above max loss
+        R.ProgressDelta = 0.1f;
+        R.Fidelity = PassingMetrics();
+        return R;
+    });
+
+    Kernel.RunTrainingCycle();
+    EXPECT_FALSE(Kernel.DidLastCyclePassGates());
+    EXPECT_EQ(Kernel.GetDeployedCheckpoints(), 0u);
+    ASSERT_EQ(Kernel.GetLastGateFailures().size(), 1u);
+    EXPECT_EQ(Kernel.GetLastGateFailures()[0], "training_loss_above_maximum");
+}
+
+TEST(NanEchoKernelDaemon, AutoDeployDisabledSkipsDeployment)
+{
+    FNanEchoKernelConfig Config;
+    Config.bAutoDeployAfterTraining = false;
+
+    FNanEchoKernel Kernel;
+    Kernel.Configure(Config);
+    Kernel.Start();
+    Kernel.SetCycleExecutor([](const FNanEchoKernelConfig&, float) {
+        FCycleResult R;
+        R.FinalLoss = 0.5f;
+        R.ProgressDelta = 0.1f;
+        R.Fidelity = PassingMetrics();
+        return R;
+    });
+
+    Kernel.RunTrainingCycle();
+    EXPECT_TRUE(Kernel.DidLastCyclePassGates());
+    EXPECT_EQ(Kernel.GetDeployedCheckpoints(), 0u);
+}
+
+TEST(NanEchoKernelDaemon, DefaultExecutorConvergesAndPassesGates)
+{
+    FNanEchoKernel Kernel;
+    Kernel.Configure(FNanEchoKernelConfig{});
+    Kernel.Start();
+
+    // Default executor: +0.15 progress per cycle (3 epochs × 0.05)
+    for (int i = 0; i < 7; ++i)
+    {
+        Kernel.RunTrainingCycle();
+    }
+    EXPECT_FLOAT_EQ(Kernel.GetTrainingProgress(), 1.0f);
+    EXPECT_EQ(Kernel.GetActivePhase(), ETrainingPhase::AdaptiveMastery);
+    EXPECT_LT(Kernel.GetLastLoss(), 2.0f);
+    EXPECT_TRUE(Kernel.DidLastCyclePassGates());
+    EXPECT_GT(Kernel.GetDeployedCheckpoints(), 0u);
+    EXPECT_GT(Kernel.GetLastFidelity().Composite(), 0.8f);
+}
+
+TEST(NanEchoKernelDaemon, TickUpdatesAttentionAndAutognosis)
+{
+    FNanEchoKernel Kernel;
+    Kernel.Configure(FNanEchoKernelConfig{});
+    Kernel.Start();
+
+    // Tick that completes a cycle: recent activity spikes to 1.0
+    Kernel.TickHours(4.0f);
+    EXPECT_FLOAT_EQ(Kernel.GetAttention().GetRecentActivity(), 1.0f);
+    EXPECT_GE(Kernel.GetAutognosis().GetObservationCount(), 1u);
+
+    // Quiet ticks decay activity and accumulate observations
+    const std::size_t Before = Kernel.GetAutognosis().GetObservationCount();
+    Kernel.TickHours(1.0f);
+    EXPECT_LT(Kernel.GetAttention().GetRecentActivity(), 1.0f);
+    EXPECT_GT(Kernel.GetAutognosis().GetObservationCount(), Before);
+}
+
+TEST(NanEchoKernelDaemon, IntrospectionReflectsConfiguredState)
+{
+    FNanEchoKernelConfig Config;
+    Config.PersonaName = "Deep Tree Echo";
+    Config.TrainingCycleIntervalHours = 2.0f;
+
+    FNanEchoKernel Kernel;
+    Kernel.Configure(Config);
+    EXPECT_EQ(Kernel.GetConfig().PersonaName, "Deep Tree Echo");
+    EXPECT_FLOAT_EQ(Kernel.GetConfig().TrainingCycleIntervalHours, 2.0f);
+    EXPECT_FLOAT_EQ(Kernel.GetTrainingProgress(), 0.0f);
+    EXPECT_EQ(Kernel.GetActivePhase(), ETrainingPhase::BasicAwareness);
+    EXPECT_EQ(Kernel.GetCompletedCycles(), 0u);
+    EXPECT_FLOAT_EQ(Kernel.GetQualityGates().MinIdentityScore, 0.8f);
+}
+
+}  // namespace

--- a/DeepTreeEcho/Testing/UnitTests/NanEchoKernelTests.cpp
+++ b/DeepTreeEcho/Testing/UnitTests/NanEchoKernelTests.cpp
@@ -633,6 +633,68 @@ TEST(NanEchoKernelDaemon, TickUpdatesAttentionAndAutognosis)
     EXPECT_GT(Kernel.GetAutognosis().GetObservationCount(), Before);
 }
 
+TEST(NanEchoKernelDaemon, ResumeFromStoppedPreservesCycleTimer)
+{
+    FNanEchoKernel Kernel;
+    Kernel.Configure(FNanEchoKernelConfig{});  // 4h interval
+    Kernel.Start();
+
+    // Accumulate partial progress toward the next cycle, then pause.
+    EXPECT_EQ(Kernel.TickHours(3.0f), 0);
+    Kernel.Stop();
+
+    // Resume: the 3h already accumulated must survive the pause.
+    EXPECT_TRUE(Kernel.Start());
+    EXPECT_EQ(Kernel.TickHours(1.0f), 1);
+    EXPECT_EQ(Kernel.GetCompletedCycles(), 1u);
+}
+
+TEST(NanEchoKernelDaemon, ReconfigureResetsCycleTimer)
+{
+    FNanEchoKernel Kernel;
+    Kernel.Configure(FNanEchoKernelConfig{});  // 4h interval
+    Kernel.Start();
+    EXPECT_EQ(Kernel.TickHours(3.0f), 0);
+    Kernel.Stop();
+
+    // A fresh Configure + Start begins a new interval from zero.
+    EXPECT_TRUE(Kernel.Configure(FNanEchoKernelConfig{}));
+    EXPECT_TRUE(Kernel.Start());
+    EXPECT_EQ(Kernel.TickHours(1.0f), 0);
+    EXPECT_EQ(Kernel.TickHours(3.0f), 1);
+}
+
+TEST(NanEchoKernelDaemon, ManualCycleRefreshesAttention)
+{
+    FNanEchoKernel Kernel;
+    Kernel.Configure(FNanEchoKernelConfig{});
+    Kernel.Start();
+
+    // Manual trigger (no TickHours involved) must spike recent activity and
+    // recompute the threshold from the post-cycle phase load.
+    EXPECT_TRUE(Kernel.RunTrainingCycle());
+    EXPECT_FLOAT_EQ(Kernel.GetAttention().GetRecentActivity(), 1.0f);
+
+    const float ExpectedLoad =
+        static_cast<float>(Kernel.GetActivePhase())
+        / static_cast<float>(FTrainingPhaseSchedule::NumPhases - 1);
+    EXPECT_FLOAT_EQ(Kernel.GetAttention().GetThreshold(),
+                    FAdaptiveAttention::ComputeThreshold(ExpectedLoad, 1.0f));
+
+    // Drive progress to completion: cognitive load follows the active phase.
+    Kernel.SetCycleExecutor([](const FNanEchoKernelConfig&, float) {
+        FCycleResult R;
+        R.FinalLoss = 0.5f;
+        R.ProgressDelta = 1.0f;
+        return R;
+    });
+    Kernel.RunTrainingCycle();
+    EXPECT_EQ(Kernel.GetActivePhase(), ETrainingPhase::AdaptiveMastery);
+    // Load 1.0, activity 1.0 → 0.5 + 0.3 - 0.2 = 0.6
+    EXPECT_FLOAT_EQ(Kernel.GetAttention().GetThreshold(), 0.6f);
+    EXPECT_FLOAT_EQ(Kernel.GetAttention().GetCognitiveLoad(), 1.0f);
+}
+
 TEST(NanEchoKernelDaemon, IntrospectionReflectsConfiguredState)
 {
     FNanEchoKernelConfig Config;


### PR DESCRIPTION
## Why

`Training/NanEchoConfig.h` defined the NanEcho training configuration (`FNanEchoTrainingConfig`) but nothing in the repo consumed it, and the NanEcho system documented in `NANECHO.md` (training phases, adaptive attention, fidelity metrics, quality gates) had no C++ kernel implementation. This PR turns those specs, plus the `AUTOGNOSIS.md` hierarchical self-image model, into a working, tested cognitive kernel daemon.

## What

**`DeepTreeEcho/NanEcho/Kernel/NanEchoKernel.h`** - header-only, standalone C++17 with no Unreal Engine dependencies (so it builds and tests outside UE; the UE `USTRUCT` converts field-for-field at the engine boundary):

- **Config mirror** of `FNanEchoTrainingConfig` (gpt2 base, ESN 512/0.9/0.3, LR 5e-5, persona "Deep Tree Echo", 4h training cycle, auto-deploy) with range validation
- **Adaptive attention** per NANECHO.md: `threshold = 0.5 + cognitive_load*0.3 - recent_activity*0.2`, clamped, with salience-based `ShouldAttend` gating
- **Five blended training phases** with the spec's overlapping progress ranges (Basic Awareness 0-20% ... Adaptive Mastery 80-100%); linear cross-fade inside overlaps with normalized weights, plus a dominant-phase query
- **Fidelity metrics + quality gates**: spec weights (identity 0.25, persona 0.20, attention 0.20, recursion 0.15, hypergraph 0.10, synergy 0.10); gates identity >= 0.8, coherence >= 0.75, adaptive >= 0.7, loss <= 2.0 decide whether a checkpoint auto-deploys
- **Autognosis self-images**: L0 raw state snapshots -> L1 pattern analysis (loss trend, progress rate, attention stability, 3-sigma anomaly detection) -> L2 meta-cognition (confidence, self-awareness score, recursion depth)
- **Daemon lifecycle**: Configure -> Start -> TickHours -> Stop; interval-driven cycle clock with multi-cycle catch-up and a pluggable executor callback so the external training pipeline (echoself Python) can be swapped in; a deterministic default executor supports testing

**`DeepTreeEcho/Testing/UnitTests/NanEchoKernelTests.cpp`** - 35 GTest cases auto-globbed into `DeepTreeEchoUnitTests`, covering config defaults/validation, the attention formula and clamping, phase-weight blending (including overlap midpoints and weight normalization across all progress values), fidelity weights, each quality gate independently plus boundary behavior, autognosis trend/stability/anomaly/confidence, and full daemon lifecycle including deploy gating.

## Verification

- Full unit suite green with MinGW GCC 16.1 + Ninja: **897/897 tests pass** (862 baseline + 35 new), `ctest -L unit`
- No existing files modified; no CMake changes needed (test glob picks up the new file)

## Notes for review

- Where NANECHO.md leaves mechanics unspecified (overlap blending shape, autognosis scoring composites, the default executor's loss curve), the implementation makes deliberate, documented choices - flagging these as the most opinion-bearing parts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Greenfield header-only library and tests only; deploy logic is counter/metadata strings with no network I/O in this diff.
> 
> **Overview**
> Introduces a **header-only C++17** `FNanEchoKernel` daemon that implements NANECHO/AUTOGNOSIS specs without Unreal: config mirroring `FNanEchoTrainingConfig`, adaptive attention, five overlapping training phases with normalized blend weights, weighted fidelity metrics and quality gates, and Autognosis L0→L1→L2 self-observation.
> 
> The daemon runs **Configure → Start → `TickHours` / manual cycles → Stop**, fires training on a configurable hour interval (with catch-up), invokes a pluggable **cycle executor** (Python pipeline hook) or a deterministic default, and records HuggingFace-style checkpoint paths when gates pass and auto-deploy is enabled.
> 
> Adds **`NanEchoKernelTests.cpp`** with 35 GTest cases covering validation, attention, phase schedule, gates, autognosis, and lifecycle (deploy gating, timer resume vs reconfigure reset). No existing sources or CMake changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d74dfdde39b777e30ff495c83cbcd16627b8c00c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->