### PR TITLE
Add GTest standalone tests for Message Protocol (F1.1.2)

### DIFF
--- a/DeepTreeEcho/Testing/UnitTests/CMakeLists.txt
+++ b/DeepTreeEcho/Testing/UnitTests/CMakeLists.txt
@@ -628,11 +628,53 @@ gtest_discover_tests(NeuralToSymbolicTranslatorTests
 )
 
 # ============================================================================
+# Lock-Free Message Queue Tests (Feature F1.1.2)
+# ============================================================================
+add_executable(LockFreeMessageQueueTests
+    LockFreeMessageQueueTests.cpp
+)
+
+target_link_libraries(LockFreeMessageQueueTests ${GTEST_LIBS})
+
+target_include_directories(LockFreeMessageQueueTests PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../
+    ${CMAKE_SOURCE_DIR}/../../../
+)
+
+gtest_discover_tests(LockFreeMessageQueueTests
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    PROPERTIES
+        LABELS "unit;message-protocol;lock-free-queue;F1.1.2"
+        TIMEOUT 60
+)
+
+# ============================================================================
+# Bidirectional Message Protocol Tests (Feature F1.1.2)
+# ============================================================================
+add_executable(MessageProtocolTests
+    MessageProtocolTests.cpp
+)
+
+target_link_libraries(MessageProtocolTests ${GTEST_LIBS})
+
+target_include_directories(MessageProtocolTests PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../
+    ${CMAKE_SOURCE_DIR}/../../../
+)
+
+gtest_discover_tests(MessageProtocolTests
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    PROPERTIES
+        LABELS "unit;message-protocol;bidirectional;F1.1.2"
+        TIMEOUT 60
+)
+
+# ============================================================================
 # All Tests Target
 # ============================================================================
 add_custom_target(run_all_tests
     COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --parallel 4
-    DEPENDS CoreTests MemoryTests AvatarCognitionTests ReservoirIntegrationTests EchoStateNetworkTests ActiveInferenceTests CortisolDynamicsTests DNAIntegrationTests CognitiveLoopTests WisdomEntelechyTests Sys6OperadTests BehavioralFrameworkTests TensorLogicTests ReservoirTopologyGeneratorTests MembraneCommChannelsTests MembraneLifecycleTests ObjectTransportRulesTests HypergraphPatternMatcherTests FutureStatePredictionTests VirtualControllerDriverTests GamingMasterySystemTests DTEAvatarAgentTests EmbodiedAutonomyPipelineTests DopaminergicRewardSystemTests LiquidStateMachineTests SymbolicToNeuralEncoderTests NeuralToSymbolicTranslatorTests
+    DEPENDS CoreTests MemoryTests AvatarCognitionTests ReservoirIntegrationTests EchoStateNetworkTests ActiveInferenceTests CortisolDynamicsTests DNAIntegrationTests CognitiveLoopTests WisdomEntelechyTests Sys6OperadTests BehavioralFrameworkTests TensorLogicTests ReservoirTopologyGeneratorTests MembraneCommChannelsTests MembraneLifecycleTests ObjectTransportRulesTests HypergraphPatternMatcherTests FutureStatePredictionTests VirtualControllerDriverTests GamingMasterySystemTests DTEAvatarAgentTests EmbodiedAutonomyPipelineTests DopaminergicRewardSystemTests LiquidStateMachineTests SymbolicToNeuralEncoderTests NeuralToSymbolicTranslatorTests LockFreeMessageQueueTests MessageProtocolTests
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     COMMENT "Running all DeepTreeEcho unit tests"
 )
@@ -662,10 +704,10 @@ endif()
 # ============================================================================
 # Installation
 # ============================================================================
-install(TARGETS CoreTests MemoryTests AvatarCognitionTests ReservoirIntegrationTests EchoStateNetworkTests ActiveInferenceTests CortisolDynamicsTests DNAIntegrationTests CognitiveLoopTests WisdomEntelechyTests Sys6OperadTests BehavioralFrameworkTests TensorLogicTests ReservoirTopologyGeneratorTests MembraneCommChannelsTests MembraneLifecycleTests ObjectTransportRulesTests HypergraphPatternMatcherTests FutureStatePredictionTests VirtualControllerDriverTests GamingMasterySystemTests DTEAvatarAgentTests EmbodiedAutonomyPipelineTests DopaminergicRewardSystemTests LiquidStateMachineTests SymbolicToNeuralEncoderTests NeuralToSymbolicTranslatorTests
+install(TARGETS CoreTests MemoryTests AvatarCognitionTests ReservoirIntegrationTests EchoStateNetworkTests ActiveInferenceTests CortisolDynamicsTests DNAIntegrationTests CognitiveLoopTests WisdomEntelechyTests Sys6OperadTests BehavioralFrameworkTests TensorLogicTests ReservoirTopologyGeneratorTests MembraneCommChannelsTests MembraneLifecycleTests ObjectTransportRulesTests HypergraphPatternMatcherTests FutureStatePredictionTests VirtualControllerDriverTests GamingMasterySystemTests DTEAvatarAgentTests EmbodiedAutonomyPipelineTests DopaminergicRewardSystemTests LiquidStateMachineTests SymbolicToNeuralEncoderTests NeuralToSymbolicTranslatorTests LockFreeMessageQueueTests MessageProtocolTests
     RUNTIME DESTINATION bin/tests
 )
 
 message(STATUS "DeepTreeEcho Tests configured")
 message(STATUS "  Build type: ${CMAKE_BUILD_TYPE}")
-message(STATUS "  Tests: CoreTests, MemoryTests, AvatarCognitionTests, ReservoirIntegrationTests, EchoStateNetworkTests, ActiveInferenceTests, CortisolDynamicsTests, DNAIntegrationTests, CognitiveLoopTests, WisdomEntelechyTests, Sys6OperadTests, BehavioralFrameworkTests, TensorLogicTests, ReservoirTopologyGeneratorTests, MembraneCommChannelsTests, MembraneLifecycleTests, ObjectTransportRulesTests, HypergraphPatternMatcherTests, FutureStatePredictionTests, VirtualControllerDriverTests, GamingMasterySystemTests, DTEAvatarAgentTests, EmbodiedAutonomyPipelineTests, DopaminergicRewardSystemTests, LiquidStateMachineTests, SymbolicToNeuralEncoderTests, NeuralToSymbolicTranslatorTests")
+message(STATUS "  Tests: CoreTests, MemoryTests, AvatarCognitionTests, ReservoirIntegrationTests, EchoStateNetworkTests, ActiveInferenceTests, CortisolDynamicsTests, DNAIntegrationTests, CognitiveLoopTests, WisdomEntelechyTests, Sys6OperadTests, BehavioralFrameworkTests, TensorLogicTests, ReservoirTopologyGeneratorTests, MembraneCommChannelsTests, MembraneLifecycleTests, ObjectTransportRulesTests, HypergraphPatternMatcherTests, FutureStatePredictionTests, VirtualControllerDriverTests, GamingMasterySystemTests, DTEAvatarAgentTests, EmbodiedAutonomyPipelineTests, DopaminergicRewardSystemTests, LiquidStateMachineTests, SymbolicToNeuralEncoderTests, NeuralToSymbolicTranslatorTests, LockFreeMessageQueueTests, MessageProtocolTests")

--- a/DeepTreeEcho/Testing/UnitTests/LockFreeMessageQueueTests.cpp
+++ b/DeepTreeEcho/Testing/UnitTests/LockFreeMessageQueueTests.cpp
@@ -1,0 +1,473 @@
+/**
+ * @file LockFreeMessageQueueTests.cpp
+ * @brief GTest-based standalone tests for lock-free message queues
+ *
+ * Feature F1.1.2 / F1.1.3: Tests cover SPSC and MPSC queue implementations
+ * used by the Bidirectional Message Protocol.
+ *
+ * Tests:
+ *  - SPSC basic enqueue/dequeue
+ *  - SPSC capacity and overflow
+ *  - SPSC fill/drain cycles
+ *  - SPSC move semantics
+ *  - SPSC wraparound correctness
+ *  - MPSC basic enqueue/dequeue
+ *  - MPSC capacity and overflow
+ *  - MPSC sequential multi-producer pattern
+ *  - Edge cases (empty dequeue, size tracking)
+ */
+
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+#include <atomic>
+#include <thread>
+
+// ============================================================================
+// Standalone copies of lock-free queue templates
+// The production headers include UE-specific headers (CoreMinimal.h,
+// HAL/Platform.h) that are unavailable outside the engine. We replicate
+// the template logic here for standalone GTest testing — the same pattern
+// used by every other GTest file in the repo.
+// ============================================================================
+
+template<typename T, size_t Capacity = 1024>
+class TestSPSCQueue
+{
+public:
+    TestSPSCQueue() : Head(0), Tail(0)
+    {
+        static_assert((Capacity & (Capacity - 1)) == 0, "Capacity must be power of 2");
+        Buffer = new T[Capacity];
+    }
+
+    ~TestSPSCQueue() { delete[] Buffer; }
+
+    bool Enqueue(const T& Item)
+    {
+        const size_t CurrentTail = Tail.load(std::memory_order_relaxed);
+        const size_t NextTail = Increment(CurrentTail);
+        if (NextTail == Head.load(std::memory_order_acquire))
+            return false;
+        Buffer[CurrentTail] = Item;
+        Tail.store(NextTail, std::memory_order_release);
+        return true;
+    }
+
+    bool Enqueue(T&& Item)
+    {
+        const size_t CurrentTail = Tail.load(std::memory_order_relaxed);
+        const size_t NextTail = Increment(CurrentTail);
+        if (NextTail == Head.load(std::memory_order_acquire))
+            return false;
+        Buffer[CurrentTail] = std::move(Item);
+        Tail.store(NextTail, std::memory_order_release);
+        return true;
+    }
+
+    bool Dequeue(T& OutItem)
+    {
+        const size_t CurrentHead = Head.load(std::memory_order_relaxed);
+        if (CurrentHead == Tail.load(std::memory_order_acquire))
+            return false;
+        OutItem = std::move(Buffer[CurrentHead]);
+        Head.store(Increment(CurrentHead), std::memory_order_release);
+        return true;
+    }
+
+    size_t Size() const
+    {
+        const size_t t = Tail.load(std::memory_order_acquire);
+        const size_t h = Head.load(std::memory_order_acquire);
+        return (t >= h) ? (t - h) : (Capacity - (h - t));
+    }
+
+    bool IsEmpty() const
+    {
+        return Head.load(std::memory_order_acquire) == Tail.load(std::memory_order_acquire);
+    }
+
+    bool IsFull() const
+    {
+        return Increment(Tail.load(std::memory_order_acquire)) == Head.load(std::memory_order_acquire);
+    }
+
+    size_t GetCapacity() const { return Capacity - 1; }
+
+private:
+    size_t Increment(size_t Index) const { return (Index + 1) & (Capacity - 1); }
+
+    alignas(64) std::atomic<size_t> Head;
+    alignas(64) std::atomic<size_t> Tail;
+    T* Buffer;
+};
+
+template<typename T, size_t Capacity = 1024>
+class TestMPSCQueue
+{
+public:
+    TestMPSCQueue() : Head(0), Tail(0)
+    {
+        static_assert((Capacity & (Capacity - 1)) == 0, "Capacity must be power of 2");
+        Buffer = new T[Capacity];
+        Sequence = new std::atomic<size_t>[Capacity];
+        for (size_t i = 0; i < Capacity; ++i)
+            Sequence[i].store(i, std::memory_order_relaxed);
+    }
+
+    ~TestMPSCQueue()
+    {
+        delete[] Buffer;
+        delete[] Sequence;
+    }
+
+    bool Enqueue(const T& Item)
+    {
+        size_t Pos;
+        while (true)
+        {
+            Pos = Tail.load(std::memory_order_relaxed);
+            const size_t Seq = Sequence[Pos & (Capacity - 1)].load(std::memory_order_acquire);
+            const intptr_t Diff = static_cast<intptr_t>(Seq) - static_cast<intptr_t>(Pos);
+            if (Diff == 0)
+            {
+                if (Tail.compare_exchange_weak(Pos, Pos + 1, std::memory_order_relaxed))
+                    break;
+            }
+            else if (Diff < 0)
+                return false;
+        }
+        Buffer[Pos & (Capacity - 1)] = Item;
+        Sequence[Pos & (Capacity - 1)].store(Pos + 1, std::memory_order_release);
+        return true;
+    }
+
+    bool Enqueue(T&& Item)
+    {
+        size_t Pos;
+        while (true)
+        {
+            Pos = Tail.load(std::memory_order_relaxed);
+            const size_t Seq = Sequence[Pos & (Capacity - 1)].load(std::memory_order_acquire);
+            const intptr_t Diff = static_cast<intptr_t>(Seq) - static_cast<intptr_t>(Pos);
+            if (Diff == 0)
+            {
+                if (Tail.compare_exchange_weak(Pos, Pos + 1, std::memory_order_relaxed))
+                    break;
+            }
+            else if (Diff < 0)
+                return false;
+        }
+        Buffer[Pos & (Capacity - 1)] = std::move(Item);
+        Sequence[Pos & (Capacity - 1)].store(Pos + 1, std::memory_order_release);
+        return true;
+    }
+
+    bool Dequeue(T& OutItem)
+    {
+        size_t Pos = Head.load(std::memory_order_relaxed);
+        while (true)
+        {
+            const size_t Seq = Sequence[Pos & (Capacity - 1)].load(std::memory_order_acquire);
+            const intptr_t Diff = static_cast<intptr_t>(Seq) - static_cast<intptr_t>(Pos + 1);
+            if (Diff == 0)
+            {
+                OutItem = std::move(Buffer[Pos & (Capacity - 1)]);
+                Sequence[Pos & (Capacity - 1)].store(Pos + Capacity, std::memory_order_release);
+                Head.store(Pos + 1, std::memory_order_release);
+                return true;
+            }
+            else if (Diff < 0)
+                return false;
+            Pos = Head.load(std::memory_order_relaxed);
+        }
+    }
+
+    size_t Size() const
+    {
+        const size_t t = Tail.load(std::memory_order_acquire);
+        const size_t h = Head.load(std::memory_order_acquire);
+        return (t >= h) ? (t - h) : (Capacity - (h - t));
+    }
+
+    bool IsEmpty() const
+    {
+        const size_t h = Head.load(std::memory_order_acquire);
+        const size_t Seq = Sequence[h & (Capacity - 1)].load(std::memory_order_acquire);
+        return static_cast<intptr_t>(Seq) - static_cast<intptr_t>(h + 1) < 0;
+    }
+
+    size_t GetCapacity() const { return Capacity; }
+
+private:
+    alignas(64) std::atomic<size_t> Head;
+    alignas(64) std::atomic<size_t> Tail;
+    T* Buffer;
+    std::atomic<size_t>* Sequence;
+};
+
+// ============================================================================
+// SPSC Queue Tests
+// ============================================================================
+
+class SPSCQueueTest : public ::testing::Test {};
+
+TEST_F(SPSCQueueTest, InitialState)
+{
+    TestSPSCQueue<int, 16> q;
+    EXPECT_TRUE(q.IsEmpty());
+    EXPECT_FALSE(q.IsFull());
+    EXPECT_EQ(q.Size(), 0u);
+    EXPECT_EQ(q.GetCapacity(), 15u); // one slot reserved
+}
+
+TEST_F(SPSCQueueTest, BasicEnqueueDequeue)
+{
+    TestSPSCQueue<int, 16> q;
+    EXPECT_TRUE(q.Enqueue(42));
+    EXPECT_FALSE(q.IsEmpty());
+    EXPECT_EQ(q.Size(), 1u);
+
+    int val = 0;
+    EXPECT_TRUE(q.Dequeue(val));
+    EXPECT_EQ(val, 42);
+    EXPECT_TRUE(q.IsEmpty());
+}
+
+TEST_F(SPSCQueueTest, MultipleItems)
+{
+    TestSPSCQueue<int, 16> q;
+    for (int i = 1; i <= 5; ++i)
+        EXPECT_TRUE(q.Enqueue(i));
+
+    EXPECT_EQ(q.Size(), 5u);
+
+    for (int i = 1; i <= 5; ++i)
+    {
+        int val = 0;
+        EXPECT_TRUE(q.Dequeue(val));
+        EXPECT_EQ(val, i);
+    }
+    EXPECT_TRUE(q.IsEmpty());
+}
+
+TEST_F(SPSCQueueTest, CapacityLimit)
+{
+    TestSPSCQueue<int, 8> q; // capacity 8, usable 7
+    for (int i = 0; i < 7; ++i)
+        EXPECT_TRUE(q.Enqueue(i));
+
+    EXPECT_TRUE(q.IsFull());
+    EXPECT_FALSE(q.Enqueue(999)); // overflow rejected
+}
+
+TEST_F(SPSCQueueTest, FillDrainCycle)
+{
+    TestSPSCQueue<int, 8> q;
+
+    // Fill completely
+    for (int i = 0; i < 7; ++i)
+        EXPECT_TRUE(q.Enqueue(i));
+    EXPECT_TRUE(q.IsFull());
+
+    // Drain completely
+    for (int i = 0; i < 7; ++i)
+    {
+        int val = -1;
+        EXPECT_TRUE(q.Dequeue(val));
+        EXPECT_EQ(val, i);
+    }
+    EXPECT_TRUE(q.IsEmpty());
+
+    // Refill — verifies wraparound
+    for (int i = 100; i < 107; ++i)
+        EXPECT_TRUE(q.Enqueue(i));
+    EXPECT_TRUE(q.IsFull());
+
+    for (int i = 100; i < 107; ++i)
+    {
+        int val = -1;
+        EXPECT_TRUE(q.Dequeue(val));
+        EXPECT_EQ(val, i);
+    }
+    EXPECT_TRUE(q.IsEmpty());
+}
+
+TEST_F(SPSCQueueTest, EmptyDequeue)
+{
+    TestSPSCQueue<int, 16> q;
+    int val = 0;
+    EXPECT_FALSE(q.Dequeue(val));
+}
+
+TEST_F(SPSCQueueTest, MoveSemantics)
+{
+    TestSPSCQueue<std::string, 16> q;
+    std::string input = "hello world";
+    EXPECT_TRUE(q.Enqueue(std::move(input)));
+
+    std::string output;
+    EXPECT_TRUE(q.Dequeue(output));
+    EXPECT_EQ(output, "hello world");
+}
+
+TEST_F(SPSCQueueTest, WraparoundCorrectness)
+{
+    TestSPSCQueue<int, 4> q; // tiny: capacity 4, usable 3
+
+    // Fill and drain multiple times to exercise wraparound
+    for (int round = 0; round < 10; ++round)
+    {
+        for (int i = 0; i < 3; ++i)
+            EXPECT_TRUE(q.Enqueue(round * 10 + i));
+
+        for (int i = 0; i < 3; ++i)
+        {
+            int val = -1;
+            EXPECT_TRUE(q.Dequeue(val));
+            EXPECT_EQ(val, round * 10 + i);
+        }
+        EXPECT_TRUE(q.IsEmpty());
+    }
+}
+
+TEST_F(SPSCQueueTest, InterleavedOps)
+{
+    TestSPSCQueue<int, 16> q;
+
+    // Interleave enqueue and dequeue
+    EXPECT_TRUE(q.Enqueue(1));
+    EXPECT_TRUE(q.Enqueue(2));
+
+    int val = 0;
+    EXPECT_TRUE(q.Dequeue(val));
+    EXPECT_EQ(val, 1);
+
+    EXPECT_TRUE(q.Enqueue(3));
+    EXPECT_TRUE(q.Dequeue(val));
+    EXPECT_EQ(val, 2);
+    EXPECT_TRUE(q.Dequeue(val));
+    EXPECT_EQ(val, 3);
+    EXPECT_TRUE(q.IsEmpty());
+}
+
+// ============================================================================
+// MPSC Queue Tests
+// ============================================================================
+
+class MPSCQueueTest : public ::testing::Test {};
+
+TEST_F(MPSCQueueTest, InitialState)
+{
+    TestMPSCQueue<int, 16> q;
+    EXPECT_TRUE(q.IsEmpty());
+    EXPECT_EQ(q.Size(), 0u);
+}
+
+TEST_F(MPSCQueueTest, BasicEnqueueDequeue)
+{
+    TestMPSCQueue<int, 16> q;
+    EXPECT_TRUE(q.Enqueue(10));
+    EXPECT_TRUE(q.Enqueue(20));
+    EXPECT_TRUE(q.Enqueue(30));
+
+    EXPECT_FALSE(q.IsEmpty());
+    EXPECT_EQ(q.Size(), 3u);
+
+    int val = 0;
+    EXPECT_TRUE(q.Dequeue(val)); EXPECT_EQ(val, 10);
+    EXPECT_TRUE(q.Dequeue(val)); EXPECT_EQ(val, 20);
+    EXPECT_TRUE(q.Dequeue(val)); EXPECT_EQ(val, 30);
+    EXPECT_TRUE(q.IsEmpty());
+}
+
+TEST_F(MPSCQueueTest, CapacityLimit)
+{
+    TestMPSCQueue<int, 8> q;
+    int accepted = 0;
+    for (int i = 0; i < 16; ++i)
+    {
+        if (q.Enqueue(i))
+            ++accepted;
+    }
+    // MPSC uses all slots via sequence numbers, capacity = 8
+    EXPECT_EQ(accepted, 8);
+}
+
+TEST_F(MPSCQueueTest, MoveSemantics)
+{
+    TestMPSCQueue<std::string, 16> q;
+    std::string s = "test message";
+    EXPECT_TRUE(q.Enqueue(std::move(s)));
+
+    std::string out;
+    EXPECT_TRUE(q.Dequeue(out));
+    EXPECT_EQ(out, "test message");
+}
+
+TEST_F(MPSCQueueTest, SequentialMultiProducerPattern)
+{
+    // Simulate multiple producers sequentially (validates the CAS logic path)
+    TestMPSCQueue<int, 64> q;
+
+    // "Producer 1" enqueues evens
+    for (int i = 0; i < 10; i += 2)
+        EXPECT_TRUE(q.Enqueue(i));
+
+    // "Producer 2" enqueues odds
+    for (int i = 1; i < 10; i += 2)
+        EXPECT_TRUE(q.Enqueue(i));
+
+    EXPECT_EQ(q.Size(), 10u);
+
+    // Consume all — order should be evens then odds
+    std::vector<int> results;
+    int val;
+    while (q.Dequeue(val))
+        results.push_back(val);
+
+    EXPECT_EQ(results.size(), 10u);
+    // Evens first
+    for (int i = 0; i < 5; ++i)
+        EXPECT_EQ(results[i], i * 2);
+    // Odds next
+    for (int i = 0; i < 5; ++i)
+        EXPECT_EQ(results[5 + i], i * 2 + 1);
+}
+
+TEST_F(MPSCQueueTest, FillDrainCycle)
+{
+    TestMPSCQueue<int, 8> q;
+
+    // Fill
+    for (int i = 0; i < 8; ++i)
+        EXPECT_TRUE(q.Enqueue(i));
+    EXPECT_FALSE(q.Enqueue(99)); // overflow
+
+    // Drain
+    for (int i = 0; i < 8; ++i)
+    {
+        int val = -1;
+        EXPECT_TRUE(q.Dequeue(val));
+        EXPECT_EQ(val, i);
+    }
+    EXPECT_TRUE(q.IsEmpty());
+
+    // Refill after drain
+    for (int i = 100; i < 108; ++i)
+        EXPECT_TRUE(q.Enqueue(i));
+    for (int i = 100; i < 108; ++i)
+    {
+        int val = -1;
+        EXPECT_TRUE(q.Dequeue(val));
+        EXPECT_EQ(val, i);
+    }
+    EXPECT_TRUE(q.IsEmpty());
+}
+
+TEST_F(MPSCQueueTest, EmptyDequeue)
+{
+    TestMPSCQueue<int, 16> q;
+    int val = 0;
+    EXPECT_FALSE(q.Dequeue(val));
+}

--- a/DeepTreeEcho/Testing/UnitTests/MessageProtocolTests.cpp
+++ b/DeepTreeEcho/Testing/UnitTests/MessageProtocolTests.cpp
@@ -1,0 +1,785 @@
+/**
+ * @file MessageProtocolTests.cpp
+ * @brief GTest-based standalone tests for Bidirectional Message Protocol
+ *
+ * Feature F1.1.2: Tests the message protocol logic — send/receive,
+ * priority scheduling, batch operations, topic routing, subscriptions,
+ * metrics tracking, command/query/event helpers, and edge cases.
+ *
+ * Follows the project's established mock-UE pattern: all UE types are
+ * replicated as plain C++ structs and the protocol logic is tested
+ * through a standalone MockBidirectionalMessageProtocol class.
+ */
+
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+#include <map>
+#include <functional>
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <atomic>
+
+// ============================================================================
+// Mock UE types for standalone testing
+// ============================================================================
+
+#ifndef WITH_UNREAL_ENGINE
+using int32 = int;
+using int64 = long long;
+using uint8 = unsigned char;
+#define TEXT(x) x
+#endif
+
+// ============================================================================
+// Standalone SPSC queue for protocol internals
+// ============================================================================
+
+template<typename T, size_t Capacity = 1024>
+class MockSPSCQueue
+{
+public:
+    MockSPSCQueue() : Head(0), Tail(0)
+    {
+        static_assert((Capacity & (Capacity - 1)) == 0, "Capacity must be power of 2");
+        Buffer.resize(Capacity);
+    }
+
+    bool Enqueue(const T& Item)
+    {
+        size_t next = (Tail + 1) & (Capacity - 1);
+        if (next == Head) return false;
+        Buffer[Tail] = Item;
+        Tail = next;
+        return true;
+    }
+
+    bool Dequeue(T& OutItem)
+    {
+        if (Head == Tail) return false;
+        OutItem = std::move(Buffer[Head]);
+        Head = (Head + 1) & (Capacity - 1);
+        return true;
+    }
+
+    size_t Size() const
+    {
+        return (Tail >= Head) ? (Tail - Head) : (Capacity - (Head - Tail));
+    }
+
+    bool IsEmpty() const { return Head == Tail; }
+
+private:
+    size_t Head;
+    size_t Tail;
+    std::vector<T> Buffer;
+};
+
+// ============================================================================
+// Mock message types (mirror production enums/structs)
+// ============================================================================
+
+enum class MockMessageType : uint8
+{
+    Command     = 0,
+    Query       = 1,
+    Event       = 2,
+    StateUpdate = 3,
+    Response    = 4
+};
+
+enum class MockMessagePriority : uint8
+{
+    Critical = 0,
+    High     = 1,
+    Normal   = 2,
+    Low      = 3
+};
+
+enum class MockCommandType : uint8
+{
+    StartProcessing = 0,
+    StopProcessing  = 1,
+    ResetState      = 2,
+    UpdateConfig    = 3,
+    FlushBuffer     = 4
+};
+
+enum class MockQueryType : uint8
+{
+    GetState         = 0,
+    GetMetrics       = 1,
+    GetConfiguration = 2,
+    GetHistory       = 3
+};
+
+enum class MockEventType : uint8
+{
+    StateChanged       = 0,
+    ThresholdExceeded  = 1,
+    ErrorOccurred      = 2,
+    ProcessingComplete = 3,
+    ConfigUpdated      = 4
+};
+
+struct MockMessage
+{
+    std::string MessageID;
+    MockMessageType MessageType = MockMessageType::Event;
+    MockMessagePriority Priority = MockMessagePriority::Normal;
+    int64 Timestamp = 0;
+    std::string SenderID;
+    std::string RecipientID;
+    std::string Topic;
+    std::string CorrelationID;
+    std::vector<uint8> PayloadData;
+    int64 EnqueueTime = 0;
+    int64 Deadline = 0;
+    bool bRequiresAck = false;
+    bool bIsBatched = false;
+    int32 BatchIndex = 0;
+    int32 BatchSize = 1;
+};
+
+struct MockMessageBatch
+{
+    std::string BatchID;
+    std::vector<MockMessage> Messages;
+    int64 CreationTime = 0;
+};
+
+struct MockQueueMetrics
+{
+    int32 QueueDepth = 0;
+    int64 TotalEnqueued = 0;
+    int64 TotalDequeued = 0;
+    int64 TotalDropped = 0;
+    float AverageLatencyUs = 0.0f;
+    float PeakLatencyUs = 0.0f;
+};
+
+struct MockRoutingConfig
+{
+    bool bEnableTopicRouting = true;
+    bool bEnablePriorityScheduling = true;
+    bool bEnableBatching = true;
+    int32 BatchSizeThreshold = 16;
+    int32 MaxQueueSizePerPriority = 1024;
+};
+
+struct MockTopicSubscription
+{
+    std::string TopicPattern;
+    std::string SubscriberID;
+    MockMessagePriority MinPriority = MockMessagePriority::Normal;
+    std::function<void(const MockMessage&)> Callback;
+};
+
+// ============================================================================
+// MockBidirectionalMessageProtocol
+// Replicates the production protocol's logic for standalone testing
+// ============================================================================
+
+class MockBidirectionalMessageProtocol
+{
+public:
+    MockBidirectionalMessageProtocol()
+    {
+        ComponentID = "MockProtocol-001";
+        NextMessageCounter = 0;
+        for (int i = 0; i < 4; ++i)
+            Metrics[i] = MockQueueMetrics{};
+    }
+
+    // --- Sending ---
+
+    bool SendMessage(const MockMessage& Message)
+    {
+        int32 idx = static_cast<int32>(Message.Priority);
+        if (idx < 0 || idx >= 4) return false;
+
+        MockMessage copy = Message;
+        copy.EnqueueTime = NowMicroseconds();
+
+        bool ok = PriorityQueues[idx].Enqueue(copy);
+        if (ok)
+        {
+            Metrics[idx].TotalEnqueued++;
+            Metrics[idx].QueueDepth = static_cast<int32>(PriorityQueues[idx].Size());
+        }
+        else
+        {
+            Metrics[idx].TotalDropped++;
+        }
+        return ok;
+    }
+
+    int32 SendBatch(const MockMessageBatch& Batch)
+    {
+        int32 ok = 0;
+        for (auto& m : Batch.Messages)
+            if (SendMessage(m)) ++ok;
+        return ok;
+    }
+
+    std::string SendCommand(const std::string& RecipientID, MockCommandType CmdType,
+                            MockMessagePriority Priority = MockMessagePriority::Normal)
+    {
+        MockMessage m;
+        m.MessageID = GenerateID();
+        m.MessageType = MockMessageType::Command;
+        m.Priority = Priority;
+        m.Timestamp = NowMicroseconds();
+        m.SenderID = ComponentID;
+        m.RecipientID = RecipientID;
+        m.Topic = "command";
+        m.PayloadData.push_back(static_cast<uint8>(CmdType));
+        return SendMessage(m) ? m.MessageID : "";
+    }
+
+    std::string SendQuery(const std::string& RecipientID, MockQueryType QType,
+                          const std::string& CorrelationID)
+    {
+        MockMessage m;
+        m.MessageID = GenerateID();
+        m.MessageType = MockMessageType::Query;
+        m.Priority = MockMessagePriority::High;
+        m.Timestamp = NowMicroseconds();
+        m.SenderID = ComponentID;
+        m.RecipientID = RecipientID;
+        m.Topic = "query";
+        m.CorrelationID = CorrelationID;
+        m.bRequiresAck = true;
+        m.PayloadData.push_back(static_cast<uint8>(QType));
+        return SendMessage(m) ? m.MessageID : "";
+    }
+
+    std::string SendEvent(const std::string& Topic, MockEventType EvType,
+                          MockMessagePriority Priority = MockMessagePriority::Normal)
+    {
+        MockMessage m;
+        m.MessageID = GenerateID();
+        m.MessageType = MockMessageType::Event;
+        m.Priority = Priority;
+        m.Timestamp = NowMicroseconds();
+        m.SenderID = ComponentID;
+        m.Topic = Topic;
+        m.PayloadData.push_back(static_cast<uint8>(EvType));
+        return SendMessage(m) ? m.MessageID : "";
+    }
+
+    // --- Receiving ---
+
+    bool ReceiveMessage(MockMessage& OutMessage)
+    {
+        if (!Config.bEnablePriorityScheduling)
+        {
+            for (int i = 0; i < 4; ++i)
+                if (PriorityQueues[i].Dequeue(OutMessage))
+                    return true;
+            return false;
+        }
+
+        // Priority order: Critical(0) > High(1) > Normal(2) > Low(3)
+        for (int i = 0; i < 4; ++i)
+        {
+            if (PriorityQueues[i].Dequeue(OutMessage))
+            {
+                int64 now = NowMicroseconds();
+                float latency = static_cast<float>(now - OutMessage.EnqueueTime);
+                Metrics[i].TotalDequeued++;
+                const float Alpha = 0.1f;
+                Metrics[i].AverageLatencyUs = (1.0f - Alpha) * Metrics[i].AverageLatencyUs + Alpha * latency;
+                if (latency > Metrics[i].PeakLatencyUs)
+                    Metrics[i].PeakLatencyUs = latency;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    int32 ReceiveMessages(int32 MaxMessages, std::vector<MockMessage>& OutMessages)
+    {
+        OutMessages.clear();
+        OutMessages.reserve(MaxMessages);
+        MockMessage m;
+        int32 count = 0;
+        while (count < MaxMessages && ReceiveMessage(m))
+        {
+            OutMessages.push_back(std::move(m));
+            ++count;
+        }
+        return count;
+    }
+
+    // --- Subscriptions ---
+
+    std::string Subscribe(const std::string& TopicPattern, const std::string& SubscriberID,
+                          MockMessagePriority MinPriority = MockMessagePriority::Normal)
+    {
+        MockTopicSubscription sub;
+        sub.TopicPattern = TopicPattern;
+        sub.SubscriberID = SubscriberID;
+        sub.MinPriority = MinPriority;
+        Subscriptions.push_back(sub);
+        return SubscriberID + ":" + TopicPattern;
+    }
+
+    void Unsubscribe(const std::string& SubscriptionID)
+    {
+        auto colon = SubscriptionID.find(':');
+        if (colon == std::string::npos) return;
+        std::string subID = SubscriptionID.substr(0, colon);
+        std::string pattern = SubscriptionID.substr(colon + 1);
+        Subscriptions.erase(
+            std::remove_if(Subscriptions.begin(), Subscriptions.end(),
+                [&](const MockTopicSubscription& s) {
+                    return s.SubscriberID == subID && s.TopicPattern == pattern;
+                }),
+            Subscriptions.end());
+    }
+
+    void UnsubscribeAll(const std::string& SubscriberID)
+    {
+        Subscriptions.erase(
+            std::remove_if(Subscriptions.begin(), Subscriptions.end(),
+                [&](const MockTopicSubscription& s) { return s.SubscriberID == SubscriberID; }),
+            Subscriptions.end());
+    }
+
+    int32 GetSubscriptionCount() const
+    {
+        return static_cast<int32>(Subscriptions.size());
+    }
+
+    // --- Metrics ---
+
+    MockQueueMetrics GetAggregatedMetrics() const
+    {
+        MockQueueMetrics agg;
+        for (int i = 0; i < 4; ++i)
+        {
+            agg.TotalEnqueued += Metrics[i].TotalEnqueued;
+            agg.TotalDequeued += Metrics[i].TotalDequeued;
+            agg.TotalDropped += Metrics[i].TotalDropped;
+            agg.QueueDepth += Metrics[i].QueueDepth;
+            if (Metrics[i].PeakLatencyUs > agg.PeakLatencyUs)
+                agg.PeakLatencyUs = Metrics[i].PeakLatencyUs;
+        }
+        return agg;
+    }
+
+    MockQueueMetrics GetMetricsForPriority(MockMessagePriority p) const
+    {
+        int32 idx = static_cast<int32>(p);
+        if (idx >= 0 && idx < 4) return Metrics[idx];
+        return MockQueueMetrics{};
+    }
+
+    void ResetMetrics()
+    {
+        for (int i = 0; i < 4; ++i)
+            Metrics[i] = MockQueueMetrics{};
+    }
+
+    // --- Configuration ---
+
+    MockRoutingConfig GetRoutingConfig() const { return Config; }
+    void SetRoutingConfig(const MockRoutingConfig& c) { Config = c; }
+
+    // --- Topic matching (exposed for testing) ---
+
+    bool MatchesTopicPattern(const std::string& Topic, const std::string& Pattern) const
+    {
+        if (Pattern == "*") return true;
+        // "prefix.*" matches topics starting with "prefix."
+        if (Pattern.size() >= 2 && Pattern.substr(Pattern.size() - 2) == ".*")
+        {
+            std::string prefix = Pattern.substr(0, Pattern.size() - 2);
+            return Topic.substr(0, prefix.size()) == prefix;
+        }
+        return Topic == Pattern;
+    }
+
+private:
+    std::string GenerateID()
+    {
+        return "msg-" + std::to_string(++NextMessageCounter);
+    }
+
+    int64 NowMicroseconds() const
+    {
+        auto now = std::chrono::high_resolution_clock::now();
+        return std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count();
+    }
+
+    std::string ComponentID;
+    std::atomic<int64> NextMessageCounter;
+    MockSPSCQueue<MockMessage, 1024> PriorityQueues[4];
+    std::vector<MockTopicSubscription> Subscriptions;
+    MockQueueMetrics Metrics[4];
+    MockRoutingConfig Config;
+};
+
+// ============================================================================
+// Test Fixture
+// ============================================================================
+
+class MessageProtocolTest : public ::testing::Test
+{
+protected:
+    MockBidirectionalMessageProtocol Protocol;
+};
+
+// ============================================================================
+// Basic Send / Receive
+// ============================================================================
+
+TEST_F(MessageProtocolTest, SendAndReceiveSingleMessage)
+{
+    MockMessage msg;
+    msg.MessageID = "test-001";
+    msg.MessageType = MockMessageType::Event;
+    msg.Priority = MockMessagePriority::Normal;
+    msg.Topic = "test.event";
+    msg.SenderID = "sender";
+    msg.RecipientID = "recipient";
+
+    EXPECT_TRUE(Protocol.SendMessage(msg));
+
+    MockMessage received;
+    EXPECT_TRUE(Protocol.ReceiveMessage(received));
+    EXPECT_EQ(received.MessageID, "test-001");
+    EXPECT_EQ(received.Topic, "test.event");
+    EXPECT_EQ(received.SenderID, "sender");
+}
+
+TEST_F(MessageProtocolTest, EmptyReceiveReturnsFalse)
+{
+    MockMessage m;
+    EXPECT_FALSE(Protocol.ReceiveMessage(m));
+}
+
+TEST_F(MessageProtocolTest, FIFOOrderWithinPriority)
+{
+    for (int i = 0; i < 5; ++i)
+    {
+        MockMessage msg;
+        msg.MessageID = "msg-" + std::to_string(i);
+        msg.Priority = MockMessagePriority::Normal;
+        Protocol.SendMessage(msg);
+    }
+
+    for (int i = 0; i < 5; ++i)
+    {
+        MockMessage out;
+        EXPECT_TRUE(Protocol.ReceiveMessage(out));
+        EXPECT_EQ(out.MessageID, "msg-" + std::to_string(i));
+    }
+}
+
+// ============================================================================
+// Priority Scheduling
+// ============================================================================
+
+TEST_F(MessageProtocolTest, PriorityOrdering)
+{
+    // Enqueue in reverse priority order
+    MockMessage low;  low.MessageID = "low";   low.Priority = MockMessagePriority::Low;
+    MockMessage norm; norm.MessageID = "norm";  norm.Priority = MockMessagePriority::Normal;
+    MockMessage high; high.MessageID = "high";  high.Priority = MockMessagePriority::High;
+    MockMessage crit; crit.MessageID = "crit";  crit.Priority = MockMessagePriority::Critical;
+
+    Protocol.SendMessage(low);
+    Protocol.SendMessage(norm);
+    Protocol.SendMessage(high);
+    Protocol.SendMessage(crit);
+
+    MockMessage r1, r2, r3, r4;
+    EXPECT_TRUE(Protocol.ReceiveMessage(r1));
+    EXPECT_TRUE(Protocol.ReceiveMessage(r2));
+    EXPECT_TRUE(Protocol.ReceiveMessage(r3));
+    EXPECT_TRUE(Protocol.ReceiveMessage(r4));
+
+    EXPECT_EQ(r1.MessageID, "crit");
+    EXPECT_EQ(r2.MessageID, "high");
+    EXPECT_EQ(r3.MessageID, "norm");
+    EXPECT_EQ(r4.MessageID, "low");
+}
+
+TEST_F(MessageProtocolTest, PriorityDisabled)
+{
+    MockRoutingConfig cfg;
+    cfg.bEnablePriorityScheduling = false;
+    Protocol.SetRoutingConfig(cfg);
+
+    MockMessage low;  low.MessageID = "low";   low.Priority = MockMessagePriority::Low;
+    MockMessage crit; crit.MessageID = "crit";  crit.Priority = MockMessagePriority::Critical;
+
+    Protocol.SendMessage(low);
+    Protocol.SendMessage(crit);
+
+    // Without priority scheduling, still dequeues from queues in order 0..3
+    MockMessage r1, r2;
+    EXPECT_TRUE(Protocol.ReceiveMessage(r1));
+    EXPECT_TRUE(Protocol.ReceiveMessage(r2));
+    EXPECT_EQ(r1.MessageID, "crit"); // queue 0 checked first
+    EXPECT_EQ(r2.MessageID, "low");
+}
+
+// ============================================================================
+// Batch Operations
+// ============================================================================
+
+TEST_F(MessageProtocolTest, BatchSendAndReceive)
+{
+    MockMessageBatch batch;
+    batch.BatchID = "batch-001";
+    for (int i = 0; i < 10; ++i)
+    {
+        MockMessage msg;
+        msg.MessageID = "b-" + std::to_string(i);
+        msg.MessageType = MockMessageType::StateUpdate;
+        msg.Priority = MockMessagePriority::Normal;
+        msg.bIsBatched = true;
+        msg.BatchIndex = i;
+        msg.BatchSize = 10;
+        batch.Messages.push_back(msg);
+    }
+
+    EXPECT_EQ(Protocol.SendBatch(batch), 10);
+
+    std::vector<MockMessage> received;
+    EXPECT_EQ(Protocol.ReceiveMessages(10, received), 10);
+
+    for (int i = 0; i < 10; ++i)
+    {
+        EXPECT_TRUE(received[i].bIsBatched);
+        EXPECT_EQ(received[i].BatchSize, 10);
+    }
+}
+
+TEST_F(MessageProtocolTest, ReceiveMessagesMaxLimit)
+{
+    for (int i = 0; i < 20; ++i)
+    {
+        MockMessage msg;
+        msg.MessageID = "x-" + std::to_string(i);
+        msg.Priority = MockMessagePriority::Normal;
+        Protocol.SendMessage(msg);
+    }
+
+    std::vector<MockMessage> out;
+    EXPECT_EQ(Protocol.ReceiveMessages(5, out), 5);
+    EXPECT_EQ(out.size(), 5u);
+}
+
+// ============================================================================
+// Command / Query / Event helpers
+// ============================================================================
+
+TEST_F(MessageProtocolTest, SendCommand)
+{
+    std::string id = Protocol.SendCommand("target", MockCommandType::StartProcessing,
+                                          MockMessagePriority::High);
+    EXPECT_FALSE(id.empty());
+
+    MockMessage r;
+    EXPECT_TRUE(Protocol.ReceiveMessage(r));
+    EXPECT_EQ(r.MessageType, MockMessageType::Command);
+    EXPECT_EQ(r.Priority, MockMessagePriority::High);
+    EXPECT_EQ(r.RecipientID, "target");
+    EXPECT_EQ(r.PayloadData.size(), 1u);
+    EXPECT_EQ(r.PayloadData[0], static_cast<uint8>(MockCommandType::StartProcessing));
+}
+
+TEST_F(MessageProtocolTest, SendQuery)
+{
+    std::string id = Protocol.SendQuery("target", MockQueryType::GetState, "corr-42");
+    EXPECT_FALSE(id.empty());
+
+    MockMessage r;
+    EXPECT_TRUE(Protocol.ReceiveMessage(r));
+    EXPECT_EQ(r.MessageType, MockMessageType::Query);
+    EXPECT_EQ(r.CorrelationID, "corr-42");
+    EXPECT_TRUE(r.bRequiresAck);
+    EXPECT_EQ(r.Priority, MockMessagePriority::High); // queries default to high
+}
+
+TEST_F(MessageProtocolTest, SendEvent)
+{
+    std::string id = Protocol.SendEvent("neural.statechange", MockEventType::StateChanged,
+                                        MockMessagePriority::Normal);
+    EXPECT_FALSE(id.empty());
+
+    MockMessage r;
+    EXPECT_TRUE(Protocol.ReceiveMessage(r));
+    EXPECT_EQ(r.MessageType, MockMessageType::Event);
+    EXPECT_EQ(r.Topic, "neural.statechange");
+}
+
+// ============================================================================
+// Subscriptions
+// ============================================================================
+
+TEST_F(MessageProtocolTest, SubscribeAndUnsubscribe)
+{
+    std::string sub1 = Protocol.Subscribe("neural.*", "sub1");
+    std::string sub2 = Protocol.Subscribe("symbolic.*", "sub2", MockMessagePriority::High);
+    std::string sub3 = Protocol.Subscribe("*", "sub3", MockMessagePriority::Low);
+
+    EXPECT_FALSE(sub1.empty());
+    EXPECT_FALSE(sub2.empty());
+    EXPECT_EQ(Protocol.GetSubscriptionCount(), 3);
+
+    Protocol.Unsubscribe(sub1);
+    EXPECT_EQ(Protocol.GetSubscriptionCount(), 2);
+
+    Protocol.UnsubscribeAll("sub2");
+    EXPECT_EQ(Protocol.GetSubscriptionCount(), 1);
+
+    Protocol.UnsubscribeAll("sub3");
+    EXPECT_EQ(Protocol.GetSubscriptionCount(), 0);
+}
+
+// ============================================================================
+// Topic Pattern Matching
+// ============================================================================
+
+TEST_F(MessageProtocolTest, TopicWildcardMatchAll)
+{
+    EXPECT_TRUE(Protocol.MatchesTopicPattern("anything", "*"));
+    EXPECT_TRUE(Protocol.MatchesTopicPattern("neural.state", "*"));
+}
+
+TEST_F(MessageProtocolTest, TopicPrefixWildcard)
+{
+    EXPECT_TRUE(Protocol.MatchesTopicPattern("neural.state", "neural.*"));
+    EXPECT_TRUE(Protocol.MatchesTopicPattern("neural.output", "neural.*"));
+    EXPECT_FALSE(Protocol.MatchesTopicPattern("symbolic.state", "neural.*"));
+}
+
+TEST_F(MessageProtocolTest, TopicExactMatch)
+{
+    EXPECT_TRUE(Protocol.MatchesTopicPattern("neural.state", "neural.state"));
+    EXPECT_FALSE(Protocol.MatchesTopicPattern("neural.state", "neural.output"));
+}
+
+// ============================================================================
+// Metrics
+// ============================================================================
+
+TEST_F(MessageProtocolTest, MetricsTracking)
+{
+    // Send 5 messages
+    for (int i = 0; i < 5; ++i)
+    {
+        MockMessage msg;
+        msg.MessageID = "m-" + std::to_string(i);
+        msg.Priority = MockMessagePriority::Normal;
+        Protocol.SendMessage(msg);
+    }
+
+    auto metrics = Protocol.GetAggregatedMetrics();
+    EXPECT_EQ(metrics.TotalEnqueued, 5);
+    EXPECT_EQ(metrics.TotalDropped, 0);
+
+    // Receive 3
+    for (int i = 0; i < 3; ++i)
+    {
+        MockMessage out;
+        Protocol.ReceiveMessage(out);
+    }
+
+    metrics = Protocol.GetAggregatedMetrics();
+    EXPECT_EQ(metrics.TotalDequeued, 3);
+}
+
+TEST_F(MessageProtocolTest, MetricsPerPriority)
+{
+    MockMessage high; high.Priority = MockMessagePriority::High;
+    MockMessage norm; norm.Priority = MockMessagePriority::Normal;
+    Protocol.SendMessage(high);
+    Protocol.SendMessage(norm);
+    Protocol.SendMessage(norm);
+
+    auto hm = Protocol.GetMetricsForPriority(MockMessagePriority::High);
+    auto nm = Protocol.GetMetricsForPriority(MockMessagePriority::Normal);
+    EXPECT_EQ(hm.TotalEnqueued, 1);
+    EXPECT_EQ(nm.TotalEnqueued, 2);
+}
+
+TEST_F(MessageProtocolTest, MetricsReset)
+{
+    MockMessage msg; msg.Priority = MockMessagePriority::Normal;
+    Protocol.SendMessage(msg);
+    Protocol.ResetMetrics();
+
+    auto m = Protocol.GetAggregatedMetrics();
+    EXPECT_EQ(m.TotalEnqueued, 0);
+    EXPECT_EQ(m.TotalDequeued, 0);
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+TEST_F(MessageProtocolTest, ConfigurationUpdate)
+{
+    MockRoutingConfig cfg;
+    cfg.bEnableTopicRouting = false;
+    cfg.bEnableBatching = false;
+    cfg.BatchSizeThreshold = 32;
+    Protocol.SetRoutingConfig(cfg);
+
+    auto retrieved = Protocol.GetRoutingConfig();
+    EXPECT_FALSE(retrieved.bEnableTopicRouting);
+    EXPECT_FALSE(retrieved.bEnableBatching);
+    EXPECT_EQ(retrieved.BatchSizeThreshold, 32);
+}
+
+// ============================================================================
+// Edge Cases
+// ============================================================================
+
+TEST_F(MessageProtocolTest, UniqueMessageIDs)
+{
+    std::string id1 = Protocol.SendCommand("a", MockCommandType::ResetState);
+    std::string id2 = Protocol.SendCommand("b", MockCommandType::FlushBuffer);
+    EXPECT_NE(id1, id2);
+}
+
+TEST_F(MessageProtocolTest, MultipleMessageTypes)
+{
+    Protocol.SendCommand("t", MockCommandType::StartProcessing, MockMessagePriority::Critical);
+    Protocol.SendQuery("t", MockQueryType::GetMetrics, "q1");
+    Protocol.SendEvent("test.topic", MockEventType::ProcessingComplete);
+
+    MockMessage r;
+    // Critical command comes first
+    EXPECT_TRUE(Protocol.ReceiveMessage(r));
+    EXPECT_EQ(r.MessageType, MockMessageType::Command);
+
+    // High-priority query next
+    EXPECT_TRUE(Protocol.ReceiveMessage(r));
+    EXPECT_EQ(r.MessageType, MockMessageType::Query);
+
+    // Normal event last
+    EXPECT_TRUE(Protocol.ReceiveMessage(r));
+    EXPECT_EQ(r.MessageType, MockMessageType::Event);
+}
+
+TEST_F(MessageProtocolTest, LargePayload)
+{
+    MockMessage msg;
+    msg.Priority = MockMessagePriority::Normal;
+    msg.PayloadData.resize(4096, 0xAB);
+    EXPECT_TRUE(Protocol.SendMessage(msg));
+
+    MockMessage out;
+    EXPECT_TRUE(Protocol.ReceiveMessage(out));
+    EXPECT_EQ(out.PayloadData.size(), 4096u);
+    EXPECT_EQ(out.PayloadData[0], 0xAB);
+    EXPECT_EQ(out.PayloadData[4095], 0xAB);
+}


### PR DESCRIPTION
## Summary

Closes #77 — [FEATURE F1.1.2] Message Protocol

Adds **37 GTest-based standalone unit tests** for the Bidirectional Message Protocol and Lock-Free Message Queue components, closing the test coverage gap for F1.1.2.

## What was done

The core implementation was already complete (`BidirectionalMessageProtocol.h/.cpp`, `LockFreeMessageQueue.h`, `MessageProtocol.fbs`). The gap was that existing tests used UE Automation macros (`IMPLEMENT_SIMPLE_AUTOMATION_TEST`) which cannot run in the standalone CMake build. Every other feature in the repo has GTest-based standalone tests — this PR adds them for the message protocol.

### New files

| File | Tests | Coverage |
|------|-------|----------|
| `LockFreeMessageQueueTests.cpp` | 16 | SPSC/MPSC queue ops: basic enqueue/dequeue, capacity limits, fill/drain cycles, move semantics, wraparound, overflow, interleaved ops |
| `MessageProtocolTests.cpp` | 21 | Send/receive, priority scheduling, batch ops, command/query/event helpers, topic routing, subscriptions, metrics tracking, config, edge cases (empty receive, large payload, unique IDs) |

### CMakeLists.txt changes

- Added `LockFreeMessageQueueTests` and `MessageProtocolTests` targets
- Labels: `unit;message-protocol;F1.1.2`
- Added to `run_all_tests`, install targets, and status output

## Testing

All 37 tests pass locally:
```
[  PASSED  ] 16 tests.  (LockFreeMessageQueueTests)
[  PASSED  ] 21 tests.  (MessageProtocolTests)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with no production runtime changes; coverage validates duplicated mock/inline logic rather than linking UE production headers directly.
> 
> **Overview**
> Adds **37 standalone GTest targets** for Feature **F1.1.2**, so message-protocol behavior can run in the CMake unit-test build (alongside other features) instead of relying only on UE Automation tests.
> 
> **`LockFreeMessageQueueTests`** (16 cases) exercises inlined **SPSC** and **MPSC** queue templates: enqueue/dequeue, capacity/overflow, fill/drain, move semantics, wraparound, and sequential multi-producer patterns—mirroring production lock-free queue logic without UE headers.
> 
> **`MessageProtocolTests`** (21 cases) drives a **`MockBidirectionalMessageProtocol`**: priority scheduling, batch send/receive, command/query/event helpers, subscriptions, topic wildcards, per-priority and aggregated metrics, routing config, and edge cases (empty receive, large payloads, unique IDs).
> 
> **`CMakeLists.txt`** registers both executables with labels `unit;message-protocol;F1.1.2`, and hooks them into **`run_all_tests`**, **install**, and status output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c051d2a0cdf33da99efd07c8e5862f263571451e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->